### PR TITLE
check EventSourceMapping FuntionResponseTypes

### DIFF
--- a/canyon.go
+++ b/canyon.go
@@ -18,10 +18,6 @@ import (
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
-	"github.com/aws/aws-lambda-go/lambdacontext"
-	"github.com/aws/aws-sdk-go-v2/config"
-	sdklambda "github.com/aws/aws-sdk-go-v2/service/lambda"
-	lambdatypes "github.com/aws/aws-sdk-go-v2/service/lambda/types"
 	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
 	"github.com/fujiwara/ridge"
 	"github.com/pires/go-proxyproto"
@@ -54,11 +50,6 @@ func RunWithContext(ctx context.Context, sqsQueueName string, mux http.Handler, 
 	return context.Cause(ctx)
 }
 
-var (
-	enableReportBatchItemFailures  map[string]bool = make(map[string]bool)
-	onceCheckFunctionResponseTypes sync.Once
-)
-
 func runWithContext(ctx context.Context, mux http.Handler, c *runOptions) error {
 	workerHandler := newWorkerHandler(mux, c)
 	serverHandler := newServerHandler(mux, c)
@@ -70,49 +61,11 @@ func runWithContext(ctx context.Context, mux http.Handler, c *runOptions) error 
 					return nil, err
 				}
 				if p.IsSQSEvent && !c.disableWorker {
-					onceCheckFunctionResponseTypes.Do(func() {
-						defer func() {
-							for k, v := range enableReportBatchItemFailures {
-								if v {
-									c.logger.Info("enable report batch item failures", "event_source_arn", k)
-								}
-							}
-						}()
-
-						awsCfg, err := config.LoadDefaultConfig(ctx)
-						if err != nil {
-							return
-						}
-						lambdaClient := sdklambda.NewFromConfig(awsCfg)
-						lc, ok := lambdacontext.FromContext(ctx)
-						if !ok {
-							c.logger.Warn("missing lambda context for check function response types")
-							return
-						}
-						p := sdklambda.NewListEventSourceMappingsPaginator(lambdaClient, &sdklambda.ListEventSourceMappingsInput{
-							FunctionName: &lc.InvokedFunctionArn,
+					if len(p.SQSEvent.Records) > 1 {
+						onceCheckFunctionResponseTypes.Do(func() {
+							checkFunctionResponseTypes(ctx, c)
 						})
-						for p.HasMorePages() {
-							list, err := p.NextPage(ctx)
-							if err != nil {
-								c.logger.Warn("failed to list event source mappings", "error", err)
-								return
-							}
-							for _, m := range list.EventSourceMappings {
-								if m.EventSourceArn == nil {
-									continue
-								}
-								if !strings.HasPrefix(*m.EventSourceArn, "arn:aws:sqs:") {
-									continue
-								}
-								for _, v := range m.FunctionResponseTypes {
-									if v == lambdatypes.FunctionResponseTypeReportBatchItemFailures {
-										enableReportBatchItemFailures[*m.EventSourceArn] = true
-									}
-								}
-							}
-						}
-					})
+					}
 					resp, err := workerHandler(ctx, p.SQSEvent)
 					if err != nil {
 						return nil, err
@@ -120,7 +73,10 @@ func runWithContext(ctx context.Context, mux http.Handler, c *runOptions) error 
 					if len(resp.BatchItemFailures) == 0 {
 						return resp, nil
 					}
-					if !enableReportBatchItemFailures[p.SQSEvent.Records[0].EventSourceARN] {
+					if len(p.SQSEvent.Records) == 1 {
+						return resp, fmt.Errorf("failed processing record(message_id=%s)", p.SQSEvent.Records[0].MessageId)
+					}
+					if !isEnableReportBatchItemFailures(ctx, p.SQSEvent.Records[0].EventSourceARN) {
 						return resp, fmt.Errorf("failed processing %d records", len(resp.BatchItemFailures))
 					}
 					return resp, nil

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,8 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.21.0
 	github.com/aws/aws-sdk-go-v2/config v1.18.39
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.11.83
+	github.com/aws/aws-sdk-go-v2/service/lambda v1.39.5
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.38.5
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.24.5
 	github.com/fujiwara/ridge v0.6.1
 	github.com/google/uuid v1.3.1
@@ -26,7 +28,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.1.36 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.35 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.15.4 // indirect
-	github.com/aws/aws-sdk-go-v2/service/s3 v1.38.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.13.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.15.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.21.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.35 h1:CdzPW9kKi
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.35/go.mod h1:QGF2Rs33W5MaN9gYdEQOBBFPLwTZkEhRwI33f7KIG0o=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.15.4 h1:v0jkRigbSD6uOdwcaUQmgEwG1BkPfAPDqaeNt/29ghg=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.15.4/go.mod h1:LhTyt8J04LL+9cIt7pYJ5lbS/U98ZmXovLOR/4LUsk8=
+github.com/aws/aws-sdk-go-v2/service/lambda v1.39.5 h1:uMvxJFS92hNW6BRX0Ou+5zb9DskgrJQHZ+5yT8FXK5Y=
+github.com/aws/aws-sdk-go-v2/service/lambda v1.39.5/go.mod h1:ByLHcf0zbHpyLTOy1iPVRPJWmAUPCiJv5k81dt52ID8=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.38.5 h1:A42xdtStObqy7NGvzZKpnyNXvoOmm+FENobZ0/ssHWk=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.38.5/go.mod h1:rDGMZA7f4pbmTtPOk5v5UM2lmX6UAbRnMDJeDvnH7AM=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.24.5 h1:RyDpTOMEJO6ycxw1vU/6s0KLFaH3M0z/z9gXHSndPTk=

--- a/lambda/example.tf
+++ b/lambda/example.tf
@@ -136,11 +136,12 @@ resource "aws_lambda_function_url" "canyon_example" {
 }
 
 resource "aws_lambda_event_source_mapping" "canyon_example" {
-  batch_size              = 10
-  event_source_arn        = aws_sqs_queue.canyon_example.arn
-  enabled                 = true
-  function_name           = aws_lambda_alias.canyon_example.arn
-  function_response_types = ["ReportBatchItemFailures"]
+  batch_size                         = 10
+  event_source_arn                   = aws_sqs_queue.canyon_example.arn
+  enabled                            = true
+  maximum_batching_window_in_seconds = 5
+  function_name                      = aws_lambda_alias.canyon_example.arn
+  function_response_types            = ["ReportBatchItemFailures"]
 }
 
 output "lambda_function_url" {

--- a/lambda/example.tf
+++ b/lambda/example.tf
@@ -68,6 +68,12 @@ data "aws_iam_policy_document" "canyon_example" {
     ]
   }
   statement {
+    resources = ["*"]
+    actions = [
+      "lambda:ListEventSourceMappings",
+    ]
+  }
+  statement {
     actions = [
       "logs:GetLog*",
       "logs:CreateLogGroup",
@@ -130,12 +136,12 @@ resource "aws_lambda_function_url" "canyon_example" {
 }
 
 resource "aws_lambda_event_source_mapping" "canyon_example" {
-  batch_size       = 10
-  event_source_arn = aws_sqs_queue.canyon_example.arn
-  enabled          = true
-  function_name    = aws_lambda_alias.canyon_example.arn
+  batch_size              = 10
+  event_source_arn        = aws_sqs_queue.canyon_example.arn
+  enabled                 = true
+  function_name           = aws_lambda_alias.canyon_example.arn
+  function_response_types = ["ReportBatchItemFailures"]
 }
-
 
 output "lambda_function_url" {
   description = "Generated function URL"

--- a/option.go
+++ b/option.go
@@ -101,6 +101,18 @@ func (c *runOptions) DebugContextWhenVarbose(ctx context.Context, msg string, ke
 	}
 }
 
+func (c *runOptions) InfoContextWhenVarbose(ctx context.Context, msg string, keysAndValues ...interface{}) {
+	if c.logVarbose {
+		c.logger.InfoContext(ctx, msg, keysAndValues...)
+	}
+}
+
+func (c *runOptions) WarnContextWhenVarbose(ctx context.Context, msg string, keysAndValues ...interface{}) {
+	if c.logVarbose {
+		c.logger.WarnContext(ctx, msg, keysAndValues...)
+	}
+}
+
 // Option is a Run() and RunWtihContext() option.
 type Option func(*runOptions)
 


### PR DESCRIPTION
if not enable FuntionResponseTypes[ReportBatchItemFailures], cannot error message handling


https://docs.aws.amazon.com/ja_jp/lambda/latest/dg/API_GetEventSourceMapping.html#API_GetEventSourceMapping_ResponseSyntax

check this value.
 if enable, return BatchItemFailures
if disable or N/A, return function error