### PR TITLE
delay seconds and Long delayed seconds with EventBridge Scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,35 @@ fallback handler called: {"foo":"bar"}
 <... continue program ...>
 ```
 
+### Long Delayed Message with EventBridge Scheduler
+
+SQS Delayed Message is max 15 minutes. if you want to more long delayed message, use EventBridge Scheduler.
+if more long delay, CreateSchedule API call with at expression.
+
+```go
+package main
+
+//...
+
+func main() {
+//...
+    scheduler, err := canyon.NewEventBridgeScheduler(ctx, "schedule-name-prefix.")
+    if err != nil {
+        slog.Error("failed to create eventbridge scheduler", "error", err)
+        os.Exit(1)
+    }
+    opts := []canyon.Option{
+        canyon.WithServerAddress(":8080", "/"),
+        canyon.WitScheduler(scheduler),
+    }
+    err := canyon.RunWithContext(ctx, "your-sqs-queue-name", http.HandlerFunc(handler), opts...)
+    if err != nil {
+        slog.Error("failed to run canyon", "error", err)
+        os.Exit(1)
+    }
+}
+```
+if use `canyon.CanyonEnv` option, `<env prefix>SCHEDULER` environment variable is set `true`, use EventBridge Scheduler.
 
 ## For testing  
 

--- a/aws.go
+++ b/aws.go
@@ -27,6 +27,7 @@ import (
 	sdklambda "github.com/aws/aws-sdk-go-v2/service/lambda"
 	lambdatypes "github.com/aws/aws-sdk-go-v2/service/lambda/types"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/scheduler"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
 	"github.com/google/uuid"
@@ -44,6 +45,10 @@ type S3Client interface {
 	manager.UploadAPIClient
 	manager.DownloadAPIClient
 	s3.HeadObjectAPIClient
+}
+
+type EventBridgeSchedulerClient interface {
+	CreateSchedule(ctx context.Context, params *scheduler.CreateScheduleInput, optFns ...func(*scheduler.Options)) (*scheduler.CreateScheduleOutput, error)
 }
 
 type sqsLongPollingService struct {

--- a/aws.go
+++ b/aws.go
@@ -27,7 +27,6 @@ import (
 	sdklambda "github.com/aws/aws-sdk-go-v2/service/lambda"
 	lambdatypes "github.com/aws/aws-sdk-go-v2/service/lambda/types"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/aws/aws-sdk-go-v2/service/scheduler"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
 	"github.com/google/uuid"
@@ -45,10 +44,6 @@ type S3Client interface {
 	manager.UploadAPIClient
 	manager.DownloadAPIClient
 	s3.HeadObjectAPIClient
-}
-
-type EventBridgeSchedulerClient interface {
-	CreateSchedule(ctx context.Context, params *scheduler.CreateScheduleInput, optFns ...func(*scheduler.Options)) (*scheduler.CreateScheduleOutput, error)
 }
 
 type sqsLongPollingService struct {

--- a/canyon.go
+++ b/canyon.go
@@ -466,6 +466,9 @@ func newWorkerSender(mux http.Handler, serializer Serializer, c *runOptions) Wor
 				if opts.MessageGroupID != nil {
 					input.MessageGroupId = opts.MessageGroupID
 				}
+				if opts.DelaySeconds != nil {
+					input.DelaySeconds = *opts.DelaySeconds
+				}
 			}
 			output, err := client.SendMessage(ctx, input)
 			if err != nil {
@@ -477,12 +480,4 @@ func newWorkerSender(mux http.Handler, serializer Serializer, c *runOptions) Wor
 			return *output.MessageId, nil
 		})
 	}
-}
-
-func SendToWorker(r *http.Request, opts *SendOptions) (string, error) {
-	workerSender := workerSenderFromContext(r.Context())
-	if workerSender == nil {
-		return "", errors.New("sqs message sender is not set: may be worker or not running with canyon")
-	}
-	return workerSender.SendToWorker(r, opts)
 }

--- a/canyon.go
+++ b/canyon.go
@@ -422,6 +422,8 @@ func newLambdaFallbackHandler(mux http.Handler, c *runOptions) lambda.Handler {
 	})
 }
 
+const DelayedSQSMessageID = "<delayed sqs message>"
+
 func newWorkerSender(mux http.Handler, serializer Serializer, c *runOptions) WorkerSender {
 	if isLambda() && c.useInMemorySQS {
 		return WorkerSenderFunc(func(r *http.Request, opts *SendOptions) (string, error) {
@@ -482,6 +484,7 @@ func newWorkerSender(mux http.Handler, serializer Serializer, c *runOptions) Wor
 				if err := c.scheduler.RegisterSchedule(ctx, input); err != nil {
 					return "", fmt.Errorf("failed to register to scheduler: %w", err)
 				}
+				return DelayedSQSMessageID, nil
 			}
 			output, err := client.SendMessage(ctx, input)
 			if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.11.86
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.39.5
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.39.0
+	github.com/aws/aws-sdk-go-v2/service/scheduler v1.3.0
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.24.5
 	github.com/fujiwara/ridge v0.6.1
 	github.com/google/uuid v1.3.1

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/mashiike/canyon
 go 1.21.0
 
 require (
+	github.com/Songmu/flextime v0.1.0
 	github.com/aws/aws-lambda-go v1.41.0
 	github.com/aws/aws-sdk-go-v2 v1.21.0
 	github.com/aws/aws-sdk-go-v2/config v1.18.42

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/aws/aws-sdk-go-v2/service/lambda v1.39.5 h1:uMvxJFS92hNW6BRX0Ou+5zb9D
 github.com/aws/aws-sdk-go-v2/service/lambda v1.39.5/go.mod h1:ByLHcf0zbHpyLTOy1iPVRPJWmAUPCiJv5k81dt52ID8=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.39.0 h1:VZ2WMkKLio5tVjYfThcy5+pb6YHGd6B6egq75FfM6hU=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.39.0/go.mod h1:rDGMZA7f4pbmTtPOk5v5UM2lmX6UAbRnMDJeDvnH7AM=
+github.com/aws/aws-sdk-go-v2/service/scheduler v1.3.0 h1:uzCEL2ILopsOcWvbmeMmmy3Sc0ybVh+nHMg5knnA0Rg=
+github.com/aws/aws-sdk-go-v2/service/scheduler v1.3.0/go.mod h1:cdpHC7Nd4Yvtf/rhRqyqqI0fzoCb0fpo2oOFVZ0HTeQ=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.24.5 h1:RyDpTOMEJO6ycxw1vU/6s0KLFaH3M0z/z9gXHSndPTk=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.24.5/go.mod h1:RZBu4jmYz3Nikzpu/VuVvRnTEJ5a+kf36WT2fcl5Q+Q=
 github.com/aws/aws-sdk-go-v2/service/sso v1.14.1 h1:YkNzx1RLS0F5qdf9v1Q8Cuv9NXCL2TkosOxhzlUPV64=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/Songmu/flextime v0.1.0 h1:sss5IALl84LbvU/cS5D1cKNd5ffT94N2BZwC+esgAJI=
+github.com/Songmu/flextime v0.1.0/go.mod h1:ofUSZ/qj7f1BfQQ6rEH4ovewJ0SZmLOjBF1xa8iE87Q=
 github.com/aws/aws-lambda-go v1.26.0/go.mod h1:jJmlefzPfGnckuHdXX7/80O3BvUUi12XOkbv4w9SGLU=
 github.com/aws/aws-lambda-go v1.41.0 h1:l/5fyVb6Ud9uYd411xdHZzSf2n86TakxzpvIoz7l+3Y=
 github.com/aws/aws-lambda-go v1.41.0/go.mod h1:jwFe2KmMsHmffA1X2R09hH6lFzJQxzI8qK17ewzbQMM=

--- a/lambda/example.tf
+++ b/lambda/example.tf
@@ -10,7 +10,10 @@ resource "aws_iam_role" "canyon_example" {
         Effect = "Allow"
         Sid    = ""
         Principal = {
-          Service = "lambda.amazonaws.com"
+          Service = [
+            "lambda.amazonaws.com",
+            "scheduler.amazonaws.com",
+          ]
         }
       }
     ]
@@ -81,6 +84,21 @@ data "aws_iam_policy_document" "canyon_example" {
       "logs:PutLogEvents",
     ]
     resources = ["*"]
+  }
+  // for use schedler
+  statement {
+    actions = [
+      "scheduler:CreateSchedule",
+    ]
+    resources = ["*"]
+  }
+  statement {
+    actions = [
+      "iam:PassRole",
+    ]
+    resources = [
+      aws_iam_role.canyon_example.arn,
+    ]
   }
 }
 

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -18,11 +18,7 @@ func main() {
 	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})))
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT, syscall.SIGQUIT)
 	defer cancel()
-	s, err := canyon.NewEventBridgeScheduler(ctx, "canyon-example.")
-	if err != nil {
-		slog.Error("failed to create scheduler", "error", err)
-		os.Exit(1)
-	}
+	os.Setenv("CANYON_SCHEDULER", "true")
 	opts := []canyon.Option{
 		canyon.WithServerAddress(":8080", "/"),
 		canyon.WithCanyonEnv("CANYON_"), // environment variables prefix
@@ -30,9 +26,8 @@ func main() {
 			slog.Error("non SQS or HTTP event", "event", string(event))
 			return errors.New("invalid lambda payload")
 		}),
-		canyon.WithScheduler(s),
 	}
-	err = canyon.RunWithContext(ctx, "canyon-example", http.HandlerFunc(handler), opts...)
+	err := canyon.RunWithContext(ctx, "canyon-example", http.HandlerFunc(handler), opts...)
 	if err != nil {
 		slog.Error("failed to run canyon", "error", err)
 		os.Exit(1)

--- a/option.go
+++ b/option.go
@@ -65,6 +65,7 @@ type runOptions struct {
 	lambdaFallbackHandler              lambda.Handler
 	stdin                              io.Reader
 	serializer                         Serializer
+	scheduler                          Scheduler
 }
 
 func defaultRunConfig(cancel context.CancelCauseFunc, sqsQueueName string) *runOptions {
@@ -395,5 +396,11 @@ func WithStdin(stdin io.Reader) Option {
 func WithSerializer(serializer Serializer) Option {
 	return func(c *runOptions) {
 		c.serializer = serializer
+	}
+}
+
+func WithScheduler(scheduler Scheduler) Option {
+	return func(c *runOptions) {
+		c.scheduler = scheduler
 	}
 }

--- a/scheduler.go
+++ b/scheduler.go
@@ -2,10 +2,147 @@ package canyon
 
 import (
 	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
 
+	"github.com/Songmu/flextime"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/scheduler"
+	"github.com/aws/aws-sdk-go-v2/service/scheduler/types"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/google/uuid"
 )
 
 type Scheduler interface {
 	RegisterSchedule(ctx context.Context, msg *sqs.SendMessageInput) error
+}
+
+type EventBridgeScheduler struct {
+	mu         sync.Mutex
+	iamRoleARN string
+	groupName  *string
+	namePrefix string
+	client     EventBridgeSchedulerClient
+}
+
+func NewEventBridgeScheduler(ctx context.Context, namePrefix string) (*EventBridgeScheduler, error) {
+	s := &EventBridgeScheduler{
+		namePrefix: namePrefix,
+	}
+	_, _, err := s.get(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func (s *EventBridgeScheduler) SetIAMRoleARN(iamRoleARN string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	arnObj, err := arn.Parse(iamRoleARN)
+	if err != nil {
+		return fmt.Errorf("invalid iam role arn: %w", err)
+	}
+	if arnObj.Service != "iam" || arnObj.Resource != "role" {
+		return fmt.Errorf("invalid iam role arn: %s", iamRoleARN)
+	}
+	s.iamRoleARN = iamRoleARN
+	return nil
+}
+
+func (s *EventBridgeScheduler) SetGroupName(groupName string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.groupName = &groupName
+}
+
+func (s *EventBridgeScheduler) SetAPIClient(client EventBridgeSchedulerClient) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.client = client
+}
+
+func (s *EventBridgeScheduler) get(ctx context.Context) (string, EventBridgeSchedulerClient, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.iamRoleARN != "" && s.client != nil {
+		return s.iamRoleARN, s.client, nil
+	}
+	awsCfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to load aws config: %w", err)
+	}
+	if s.client == nil {
+		s.client = scheduler.NewFromConfig(awsCfg)
+	}
+	if s.iamRoleARN == "" {
+		stsClient := sts.NewFromConfig(awsCfg)
+		output, err := stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+		if err != nil {
+			return "", nil, fmt.Errorf("failed to get caller identity: %w", err)
+		}
+		// arn:aws:sts::<account_id>:assumed-role/<IAMRoleARN>/<session_name>
+		arnObj, err := arn.Parse(*output.Arn)
+		if err != nil {
+			return "", nil, fmt.Errorf("invalid caller identity arn: %w", err)
+		}
+		resourceParts := strings.Split(arnObj.Resource, "/")
+		if arnObj.Service != "sts" || len(resourceParts) != 3 || resourceParts[0] != "assumed-role" {
+			return "", nil, fmt.Errorf("unexpected caller identity arn: %s", *output.Arn)
+		}
+		s.iamRoleARN = fmt.Sprintf(
+			"arn:aws:iam::%s:role/%s",
+			arnObj.AccountID,
+			strings.Split(arnObj.Resource, "/")[1],
+		)
+	}
+	return s.iamRoleARN, s.client, nil
+}
+
+func (s *EventBridgeScheduler) RegisterSchedule(ctx context.Context, msg *sqs.SendMessageInput) error {
+	now := flextime.Now()
+	iamRoleARN, client, err := s.get(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get iam role arn: %w", err)
+	}
+	scheduledAt := now.Add(time.Duration(msg.DelaySeconds) * time.Second)
+	name := fmt.Sprintf("%s%s", s.namePrefix, uuid.New().String())
+	if len(name) > 64 {
+		name = name[:64]
+	}
+	sqsArn, err := sqsQueueURLToArn(*msg.QueueUrl)
+	if err != nil {
+		return fmt.Errorf("failed to parse sqs queue url: %w", err)
+	}
+	output, err := client.CreateSchedule(ctx, &scheduler.CreateScheduleInput{
+		Name:      aws.String(name),
+		GroupName: s.groupName,
+		FlexibleTimeWindow: &types.FlexibleTimeWindow{
+			Mode: types.FlexibleTimeWindowModeOff,
+		},
+		ScheduleExpression:         aws.String(fmt.Sprintf("at(%s)", scheduledAt.Format("2006-01-02T15:04:05"))),
+		ScheduleExpressionTimezone: aws.String(scheduledAt.Location().String()),
+		Description:                aws.String(fmt.Sprintf("canyon delayed sqs message, scheduled at %s", scheduledAt.Format("2006-01-02T15:04:05"))),
+		ActionAfterCompletion:      types.ActionAfterCompletionDelete,
+		State:                      types.ScheduleStateEnabled,
+		Target: &types.Target{
+			Arn:     aws.String(sqsArn),
+			RoleArn: aws.String(iamRoleARN),
+			Input:   msg.MessageBody,
+			SqsParameters: &types.SqsParameters{
+				MessageGroupId: msg.MessageGroupId,
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create schedule: %w", err)
+	}
+	slog.InfoContext(ctx, "create schedule", "name", name, "scheduled_at", scheduledAt, "arn", *output.ScheduleArn)
+	return nil
 }

--- a/scheduler.go
+++ b/scheduler.go
@@ -1,0 +1,11 @@
+package canyon
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+)
+
+type Scheduler interface {
+	RegisterSchedule(ctx context.Context, msg *sqs.SendMessageInput) error
+}

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -1,0 +1,39 @@
+package canyon
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInMemoryScheduler(t *testing.T) {
+	var logs bytes.Buffer
+	t.Cleanup(func() {
+		t.Log("Logs\n", logs.String())
+	})
+	sqsClient := &inMemorySQSClient{
+		visibilityTimeout: time.Second,
+		logger:            slog.New(slog.NewJSONHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug})),
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	getQueueURLResult, err := sqsClient.GetQueueUrl(ctx, &sqs.GetQueueUrlInput{
+		QueueName: aws.String("test-queue"),
+	})
+	require.NoError(t, err)
+	schedler := NewInMemoryScheduler(func() SQSClient {
+		return sqsClient
+	})
+	err = schedler.RegisterSchedule(ctx, &sqs.SendMessageInput{
+		QueueUrl:     getQueueURLResult.QueueUrl,
+		MessageBody:  aws.String("test"),
+		DelaySeconds: 1,
+	})
+	require.NoError(t, err)
+}

--- a/serializer.go
+++ b/serializer.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"strconv"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -109,6 +110,13 @@ func (s *DefaultSerializer) Serialize(ctx context.Context, r *http.Request) (*sq
 	}
 	if str := r.Header.Get(HeaderSQSMessageGroupID); str != "" {
 		msg.MessageGroupId = aws.String(str)
+	}
+	if str := r.Header.Get(HeaderSQSMessageDelaySeconds); str != "" {
+		delaysSeconds, err := strconv.ParseInt(str, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse delay seconds: %w", err)
+		}
+		msg.DelaySeconds = int32(delaysSeconds)
 	}
 	return msg, nil
 }

--- a/util.go
+++ b/util.go
@@ -59,6 +59,7 @@ func coalesce(strs ...*string) string {
 const (
 	HeaderSQSMessageID              = "Sqs-Message-Id"
 	HeaderSQSMessageGroupID         = "Sqs-Message-Group-Id"
+	HeaderSQSMessageDelaySeconds    = "Sqs-Message-Delay-Seconds"
 	HeaderSQSEventSource            = "Sqs-Event-Source"
 	HeaderSQSEventSourceArn         = "Sqs-Event-Source-Arn"
 	HeaderSQSAwsRegionHeader        = "Sqs-Aws-Region"

--- a/util_test.go
+++ b/util_test.go
@@ -88,3 +88,17 @@ func TestParseURL(t *testing.T) {
 		require.Equal(t, c[3], u.Path, "should have path")
 	}
 }
+
+func TestSQSQueueURLToArn(t *testing.T) {
+	cases := [][]string{
+		{"https://sqs.ap-northeast-1.amazonaws.com/123456789012/MyQueue", "arn:aws:sqs:ap-northeast-1:123456789012:MyQueue"},
+		{"https://sqs.ap-northeast-1.amazonaws.com/123456789012/YourQueue", "arn:aws:sqs:ap-northeast-1:123456789012:YourQueue"},
+		{"https://sqs.ap-northeast-1.amazonaws.com/123456789012/MyQueue.fifo", "arn:aws:sqs:ap-northeast-1:123456789012:MyQueue.fifo"},
+		{"https://sqs.us-east-1.amazonaws.com/123456789012/YourQueue.fifo", "arn:aws:sqs:us-east-1:123456789012:YourQueue.fifo"},
+	}
+	for _, c := range cases {
+		arnStr, err := sqsQueueURLToArn(c[0])
+		require.NoError(t, err, "should parse url")
+		require.Equal(t, c[1], arnStr, "should have arn")
+	}
+}


### PR DESCRIPTION
This branch adds an EventBridge Scheduler to the Go library called Canyon. By using the EventBridge Scheduler, you can send long-delayed messages that exceed the maximum 15 minutes of SQS Delayed Message. With this change, you can use Canyon to run an HTTP server in a local environment instead of an AWS Lambda function, and use the EventBridge Scheduler to send messages after a specified time