### PR TITLE
 Add support for Retry-After header in worker

### DIFF
--- a/aws.go
+++ b/aws.go
@@ -38,6 +38,7 @@ type SQSClient interface {
 	DeleteMessage(ctx context.Context, params *sqs.DeleteMessageInput, optFns ...func(*sqs.Options)) (*sqs.DeleteMessageOutput, error)
 	GetQueueUrl(ctx context.Context, params *sqs.GetQueueUrlInput, optFns ...func(*sqs.Options)) (*sqs.GetQueueUrlOutput, error)
 	GetQueueAttributes(ctx context.Context, params *sqs.GetQueueAttributesInput, optFns ...func(*sqs.Options)) (*sqs.GetQueueAttributesOutput, error)
+	ChangeMessageVisibilityBatch(ctx context.Context, params *sqs.ChangeMessageVisibilityBatchInput, optFns ...func(*sqs.Options)) (*sqs.ChangeMessageVisibilityBatchOutput, error)
 }
 
 type S3Client interface {
@@ -253,6 +254,7 @@ type inMemorySQSClient struct {
 	messageIDByReceiptHandle map[string]string
 	maxReceiveCount          int
 	visibilityTimeout        time.Duration
+	messageVisibilityTimeout map[string]time.Duration
 	logger                   *slog.Logger
 	dlq                      *json.Encoder
 }
@@ -282,6 +284,9 @@ func (c *inMemorySQSClient) prepare() {
 		if c.visibilityTimeout == 0 {
 			c.visibilityTimeout = 30 * time.Second
 		}
+		if c.messageVisibilityTimeout == nil {
+			c.messageVisibilityTimeout = make(map[string]time.Duration)
+		}
 		if c.maxReceiveCount == 0 {
 			c.maxReceiveCount = 3
 		}
@@ -293,6 +298,42 @@ func (c *inMemorySQSClient) prepare() {
 		}
 	})
 }
+
+func (c *inMemorySQSClient) ChangeMessageVisibilityBatch(ctx context.Context, params *sqs.ChangeMessageVisibilityBatchInput, optFns ...func(*sqs.Options)) (*sqs.ChangeMessageVisibilityBatchOutput, error) {
+	c.prepare()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	ret := &sqs.ChangeMessageVisibilityBatchOutput{
+		Failed:     make([]types.BatchResultErrorEntry, 0, len(params.Entries)),
+		Successful: make([]types.ChangeMessageVisibilityBatchResultEntry, 0),
+	}
+	for _, entry := range params.Entries {
+		msgID, ok := c.messageIDByReceiptHandle[*entry.ReceiptHandle]
+		if !ok {
+			ret.Failed = append(ret.Failed, types.BatchResultErrorEntry{
+				Id:          entry.Id,
+				Code:        aws.String("ReceiptHandleIsInvalid"),
+				Message:     aws.String("The input receipt handle is invalid."),
+				SenderFault: true,
+			})
+			continue
+		}
+		if _, ok := c.messages[msgID]; !ok {
+			ret.Failed = append(ret.Failed, types.BatchResultErrorEntry{
+				Id:          entry.Id,
+				Code:        aws.String("MessageNotExist"),
+				Message:     aws.String("The message identified by the receipt handle does not exist or is not available for visibility timeout change."),
+				SenderFault: true,
+			})
+		}
+		c.messageVisibilityTimeout[msgID] = time.Duration(entry.VisibilityTimeout) * time.Second
+		ret.Successful = append(ret.Successful, types.ChangeMessageVisibilityBatchResultEntry{
+			Id: entry.Id,
+		})
+	}
+	return ret, nil
+}
+
 func (c *inMemorySQSClient) SendMessage(ctx context.Context, params *sqs.SendMessageInput, optFns ...func(*sqs.Options)) (*sqs.SendMessageOutput, error) {
 	c.prepare()
 	msg := &types.Message{
@@ -386,11 +427,12 @@ func (c *inMemorySQSClient) ReceiveMessage(ctx context.Context, params *sqs.Rece
 				}
 				msg := c.messages[key]
 				if is, ok := c.isProcessing[key]; ok && is {
-					if time.Since(c.processingStartTime[key]) < c.visibilityTimeout {
+					if time.Since(c.processingStartTime[key]) < c.messageVisibilityTimeout[key] {
 						continue
 					}
 					delete(c.isProcessing, key)
 					delete(c.processingStartTime, key)
+					delete(c.messageVisibilityTimeout, key)
 					delete(c.messageIDByReceiptHandle, *msg.ReceiptHandle)
 					if c.approximateReceiveCount[key] >= c.maxReceiveCount {
 						c.logger.InfoContext(ctx, "delete message because approximate receive count reached to max recevice count", "message_id", key, "approximate_receive_count", c.approximateReceiveCount[*msg.MessageId], "max_receive_count", c.maxReceiveCount)
@@ -402,6 +444,11 @@ func (c *inMemorySQSClient) ReceiveMessage(ctx context.Context, params *sqs.Rece
 				}
 				c.isProcessing[key] = true
 				c.processingStartTime[key] = time.Now()
+				if params.VisibilityTimeout > 0 {
+					c.messageVisibilityTimeout[key] = time.Duration(params.VisibilityTimeout) * time.Second
+				} else {
+					c.messageVisibilityTimeout[key] = c.visibilityTimeout
+				}
 				c.approximateReceiveCount[key]++
 				receiptHandle := fmt.Sprintf(
 					"%s/%s",

--- a/canyon.go
+++ b/canyon.go
@@ -9,15 +9,18 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	"log/slog"
 
+	"github.com/Songmu/flextime"
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
 	"github.com/aws/smithy-go"
 	"github.com/fujiwara/ridge"
@@ -330,6 +333,7 @@ func newWorkerHandler(mux http.Handler, c *runOptions) sqsEventLambdaHandlerFunc
 	var once sync.Once
 	var visibilityTimeout time.Duration = -1 * time.Second
 	return func(ctx context.Context, event *events.SQSEvent) (*events.SQSEventResponse, error) {
+		handleStart := flextime.Now()
 		once.Do(func() {
 			queueURL, client := c.SQSClientAndQueueURL()
 			vt, err := getVisibilityTimeout(ctx, queueURL, client)
@@ -355,6 +359,34 @@ func newWorkerHandler(mux http.Handler, c *runOptions) sqsEventLambdaHandlerFunc
 		}
 		messageIds := make([]string, 0, len(event.Records))
 		completed := make(map[string]bool, len(event.Records))
+		changeMessageVisibilityBatchInput := &sqs.ChangeMessageVisibilityBatchInput{
+			QueueUrl: aws.String(c.sqsQueueURL),
+		}
+		onFailure := func(record events.SQSMessage) {
+			mu.Lock()
+			defer mu.Unlock()
+			resp.BatchItemFailures = append(resp.BatchItemFailures, events.SQSBatchItemFailure{
+				ItemIdentifier: record.MessageId,
+			})
+			completed[record.MessageId] = true
+		}
+		onSuccess := func(record events.SQSMessage) {
+			mu.Lock()
+			defer mu.Unlock()
+			completed[record.MessageId] = true
+		}
+		setRetryAfter := func(record *events.SQSMessage, retryAfterSeconds int32) {
+			mu.Lock()
+			defer mu.Unlock()
+			changeMessageVisibilityBatchInput.Entries = append(
+				changeMessageVisibilityBatchInput.Entries,
+				types.ChangeMessageVisibilityBatchRequestEntry{
+					Id:                aws.String(record.MessageId),
+					ReceiptHandle:     aws.String(record.ReceiptHandle),
+					VisibilityTimeout: retryAfterSeconds, // after adding current visibility timeout
+				},
+			)
+		}
 		for _, record := range event.Records {
 			wg.Add(1)
 			_logger := logger.With(slog.String("message_id", record.MessageId))
@@ -369,12 +401,7 @@ func newWorkerHandler(mux http.Handler, c *runOptions) sqsEventLambdaHandlerFunc
 						"failed to restore request from sqs message",
 						"error", err,
 					)
-					mu.Lock()
-					resp.BatchItemFailures = append(resp.BatchItemFailures, events.SQSBatchItemFailure{
-						ItemIdentifier: record.MessageId,
-					})
-					completed[record.MessageId] = true
-					mu.Unlock()
+					onFailure(record)
 					return
 				}
 				embededCtx := EmbedIsWorkerInContext(ctx, true)
@@ -387,17 +414,25 @@ func newWorkerHandler(mux http.Handler, c *runOptions) sqsEventLambdaHandlerFunc
 						"failed worker handler",
 						"status_code", w.statusCode,
 					)
-					mu.Lock()
-					resp.BatchItemFailures = append(resp.BatchItemFailures, events.SQSBatchItemFailure{
-						ItemIdentifier: record.MessageId,
-					})
-					completed[record.MessageId] = true
-					mu.Unlock()
+					onFailure(record)
+					retryAfter := workerResp.Header.Get("Retry-After")
+					if retryAfter == "" {
+						return
+					}
+					retryAfterSeconds, err := strconv.ParseInt(retryAfter, 10, 32)
+					if err != nil {
+						_logger.WarnContext(
+							ctx,
+							"failed to parse Retry-After header",
+							"error", err,
+							"retry_after", retryAfter,
+						)
+						return
+					}
+					setRetryAfter(&record, int32(retryAfterSeconds))
 					return
 				}
-				mu.Lock()
-				completed[record.MessageId] = true
-				mu.Unlock()
+				onSuccess(record)
 			}(record)
 		}
 		allDone := make(chan struct{})
@@ -420,6 +455,14 @@ func newWorkerHandler(mux http.Handler, c *runOptions) sqsEventLambdaHandlerFunc
 					})
 				}
 				mu.Unlock()
+			}
+		}
+		if len(changeMessageVisibilityBatchInput.Entries) > 0 {
+			for i := range changeMessageVisibilityBatchInput.Entries {
+				changeMessageVisibilityBatchInput.Entries[i].VisibilityTimeout += int32(time.Since(handleStart).Seconds())
+			}
+			if _, err := c.sqsClient.ChangeMessageVisibilityBatch(ctx, changeMessageVisibilityBatchInput); err != nil {
+				logger.WarnContext(ctx, "failed to change message visibility", "error", err)
 			}
 		}
 		return &resp, nil

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,31 @@
+package canyon
+
+import "errors"
+
+type ErrorWithRetryAfter struct {
+	Err        error
+	RetryAfter int32
+}
+
+func WrapRetryAfter(err error, retryAfter int32) error {
+	return &ErrorWithRetryAfter{
+		Err:        err,
+		RetryAfter: retryAfter,
+	}
+}
+
+func (e *ErrorWithRetryAfter) Error() string {
+	return e.Err.Error()
+}
+
+func (e *ErrorWithRetryAfter) Unwrap() error {
+	return e.Err
+}
+
+func ErrorHasRetryAfter(err error) (int32, bool) {
+	var e *ErrorWithRetryAfter
+	if errors.As(err, &e) {
+		return e.RetryAfter, true
+	}
+	return 0, false
+}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.39.0
 	github.com/aws/aws-sdk-go-v2/service/scheduler v1.3.0
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.24.5
+	github.com/aws/aws-sdk-go-v2/service/sts v1.22.0
+	github.com/aws/smithy-go v1.14.2
 	github.com/fujiwara/ridge v0.6.1
 	github.com/google/uuid v1.3.1
 	github.com/pires/go-proxyproto v0.7.0
@@ -32,8 +34,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.15.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.14.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.17.1 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sts v1.22.0 // indirect
-	github.com/aws/smithy-go v1.14.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/lambda/example.tf
+++ b/lambda/example.tf
@@ -34,7 +34,7 @@ resource "aws_iam_role_policy_attachment" "canyon_example" {
 resource "aws_sqs_queue" "canyon_example" {
   name                       = "canyon-example"
   message_retention_seconds  = 86400
-  visibility_timeout_seconds = 30
+  visibility_timeout_seconds = 300
   redrive_policy = jsonencode({
     deadLetterTargetArn = aws_sqs_queue.canyon_example_dlq.arn
     maxReceiveCount     = 3

--- a/lambda/function.json
+++ b/lambda/function.json
@@ -14,7 +14,7 @@
   "Role": "arn:aws:iam::{{ must_env `AWS_ACCOUNT_ID` }}:role/canyon-example",
   "Runtime": "provided.al2",
   "Tags": {},
-  "Timeout": 30,
+  "Timeout": 300,
   "TracingConfig": {
       "Mode": "PassThrough"
   }

--- a/option.go
+++ b/option.go
@@ -252,12 +252,15 @@ func WithVarbose() Option {
 // if set this option, canyon not used real AWS SQS.
 // only used on memory queue.
 // for local development.
-func WithInMemoryQueue(visibilityTimeout time.Duration, maxReceiveCount int64, dlq io.Writer) Option {
+func WithInMemoryQueue(visibilityTimeout time.Duration, maxReceiveCount int32, dlq io.Writer) Option {
 	return func(c *runOptions) {
 		c.useInMemorySQS = true
+		c.inMemorySQSClientVisibilityTimeout = visibilityTimeout
+		c.inMemorySQSClientMaxReceiveCount = maxReceiveCount
 		if dlq == nil {
-			c.inMemorySQSClientDLQ = io.Discard
+			dlq = io.Discard
 		}
+		c.inMemorySQSClientDLQ = dlq
 	}
 }
 


### PR DESCRIPTION
This PR adds support for the Retry-After header in the worker. If the handler's response includes a Retry-After header, the worker will call ChangeMessageVisibility to adjust the retry duration. If the Retry-After header is not present, the worker will wait for the base retry duration plus jitter.

In addition, this PR adds an ErrorWithRetryAfter wrapper error for people who want to determine the retry duration based on deserialization errors when creating their own serializer. If an error wrapped in ErrorWithRetryAfter is returned during deserialization, the worker will also call ChangeMessageVisibility at that time.