### PR TITLE
fix ChangeMessageVisibility

### DIFF
--- a/aws.go
+++ b/aws.go
@@ -326,7 +326,7 @@ func (c *inMemorySQSClient) ChangeMessageVisibilityBatch(ctx context.Context, pa
 				SenderFault: true,
 			})
 		}
-		c.messageVisibilityTimeout[msgID] = time.Duration(entry.VisibilityTimeout) * time.Second
+		c.messageVisibilityTimeout[msgID] = time.Since(c.processingStartTime[msgID]) + time.Duration(entry.VisibilityTimeout)*time.Second
 		ret.Successful = append(ret.Successful, types.ChangeMessageVisibilityBatchResultEntry{
 			Id: entry.Id,
 		})

--- a/canyon.go
+++ b/canyon.go
@@ -16,7 +16,6 @@ import (
 
 	"log/slog"
 
-	"github.com/Songmu/flextime"
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -334,7 +333,6 @@ func newWorkerHandler(mux http.Handler, c *runOptions) sqsEventLambdaHandlerFunc
 	var visibilityTimeout time.Duration = -1 * time.Second
 	var sqsClient SQSClient
 	return func(ctx context.Context, event *events.SQSEvent) (*events.SQSEventResponse, error) {
-		handleStart := flextime.Now()
 		once.Do(func() {
 			queueURL, client := c.SQSClientAndQueueURL()
 			sqsClient = client
@@ -465,9 +463,6 @@ func newWorkerHandler(mux http.Handler, c *runOptions) sqsEventLambdaHandlerFunc
 			}
 		}
 		if len(changeMessageVisibilityBatchInput.Entries) > 0 {
-			for i := range changeMessageVisibilityBatchInput.Entries {
-				changeMessageVisibilityBatchInput.Entries[i].VisibilityTimeout += int32(time.Since(handleStart).Seconds())
-			}
 			if _, err := sqsClient.ChangeMessageVisibilityBatch(ctx, changeMessageVisibilityBatchInput); err != nil {
 				logger.WarnContext(ctx, "failed to change message visibility", "error", err)
 			}


### PR DESCRIPTION
https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ChangeMessageVisibility.html
> For example, if the default timeout for a queue is 60 seconds, 15 seconds have elapsed since you received the message, and you send a ChangeMessageVisibility call with VisibilityTimeout set to 10 seconds, the 10 seconds begin to count from the time that you make the ChangeMessageVisibility call. Thus, any attempt to change the visibility timeout or to delete that message 10 seconds after you initially change the visibility timeout (a total of 25 seconds) might result in an error.

no need add current time