### PR TITLE
Updated case conversion to consider common initialisms

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/google/uuid v1.3.1
 	github.com/pires/go-proxyproto v0.7.0
 	github.com/stretchr/testify v1.8.4
+	golang.org/x/text v0.13.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/urfave/cli/v2 v2.2.0/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
+golang.org/x/text v0.13.0 h1:ablQoSUd0tRdKxZewP80B+BaqeKJuVhuRxj/dkrun3k=
+golang.org/x/text v0.13.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/util_test.go
+++ b/util_test.go
@@ -28,10 +28,14 @@ func ReadJSON[T any](t *testing.T, path string) *T {
 
 func TestCamelCaseToKebabCase(t *testing.T) {
 	require.Equal(t, "Foo-Bar-Baz", camelCaseToKebabCase("FooBarBaz"))
-	require.Equal(t, "foo-Bar-Baz", camelCaseToKebabCase("fooBarBaz"))
-	require.Equal(t, "foo-bar-baz", camelCaseToKebabCase("foo-bar-baz"))
-	require.Equal(t, "foo_bar_baz", camelCaseToKebabCase("foo_bar_baz"))
+	require.Equal(t, "Foo-Bar-Baz", camelCaseToKebabCase("fooBarBaz"))
+	require.Equal(t, "Foo-Bar-Baz", camelCaseToKebabCase("foo-bar-baz"))
+	require.Equal(t, "Foo_bar_baz", camelCaseToKebabCase("foo_bar_baz"))
 	require.Equal(t, "foo bar baz", camelCaseToKebabCase("foo bar baz"))
+
+	require.Equal(t, "Aws-Trace-Id", camelCaseToKebabCase("AWSTraceID"))
+	require.Equal(t, "Http-Server-Ip", camelCaseToKebabCase("HTTPServerIP"))
+	require.Equal(t, "Http-Server-Url-Test", camelCaseToKebabCase("HTTPServerURLTest"))
 }
 
 func TestKebabCaseToCamelCase(t *testing.T) {
@@ -40,6 +44,10 @@ func TestKebabCaseToCamelCase(t *testing.T) {
 	require.Equal(t, "fooBarBaz", kebabCaseToCamelCase("foo-bar-baz"))
 	require.Equal(t, "foo_bar_baz", kebabCaseToCamelCase("foo_bar_baz"))
 	require.Equal(t, "foo bar baz", kebabCaseToCamelCase("foo bar baz"))
+
+	require.Equal(t, "AWSTraceID", kebabCaseToCamelCase("Aws-Trace-Id"))
+	require.Equal(t, "HTTPServerIP", kebabCaseToCamelCase("Http-Server-Ip"))
+	require.Equal(t, "HTTPServerURLTest", kebabCaseToCamelCase("Http-Server-Url-Test"))
 }
 
 func TestRundomBytes(t *testing.T) {


### PR DESCRIPTION
`AWSTraceID` => `A-W-S-Trace-Id`

fixed: `Aws-Trace-Id`