### PR TITLE
Add Lambda middleware interface

### DIFF
--- a/option.go
+++ b/option.go
@@ -72,7 +72,7 @@ type runOptions struct {
 	scheduler                          Scheduler
 	workerTimeoutMergin                time.Duration
 	lambdaOptions                      []lambda.Option
-	lambdaMiddlewares                  []func(interface{}) interface{}
+	lambdaMiddlewares                  []func(lambda.Handler) lambda.Handler
 }
 
 func defaultRunConfig(cancel context.CancelCauseFunc, sqsQueueName string) *runOptions {
@@ -549,7 +549,7 @@ func WithEnableSIGTERM(callbacks ...func()) Option {
 
 // WithLambdaMiddlewares returns a new Option that sets the lambda middlewares.
 // if set this option, canyon lambda handler use this middlewares.
-func WithLambdaMiddlewares(middlewares ...func(interface{}) interface{}) Option {
+func WithLambdaMiddlewares(middlewares ...func(lambda.Handler) lambda.Handler) Option {
 	return func(c *runOptions) {
 		c.lambdaMiddlewares = append(c.lambdaMiddlewares, middlewares...)
 	}

--- a/option.go
+++ b/option.go
@@ -72,6 +72,7 @@ type runOptions struct {
 	scheduler                          Scheduler
 	workerTimeoutMergin                time.Duration
 	lambdaOptions                      []lambda.Option
+	lambdaMiddlewares                  []func(interface{}) interface{}
 }
 
 func defaultRunConfig(cancel context.CancelCauseFunc, sqsQueueName string) *runOptions {
@@ -544,4 +545,12 @@ func WithLambdaOptions(options ...lambda.Option) Option {
 // this options is ailias of WithLambdaOptions(lambda.WithEnableSIGTERM(callbacks...)).
 func WithEnableSIGTERM(callbacks ...func()) Option {
 	return WithLambdaOptions(lambda.WithEnableSIGTERM(callbacks...))
+}
+
+// WithLambdaMiddlewares returns a new Option that sets the lambda middlewares.
+// if set this option, canyon lambda handler use this middlewares.
+func WithLambdaMiddlewares(middlewares ...func(interface{}) interface{}) Option {
+	return func(c *runOptions) {
+		c.lambdaMiddlewares = append(c.lambdaMiddlewares, middlewares...)
+	}
 }


### PR DESCRIPTION
## Background

https://github.com/open-telemetry/opentelemetry-go-contrib/blob/main/instrumentation/github.com/aws/aws-lambda-go/otellambda/README.md

canyon can not use `OpenTelemetry AWS Lambda Instrumentation for Golang`
This is because the handler is generated internally.
Therefore, prepare an interface to wrap the generated handler.

for example
```go
func main() {
//...
opts = append(opts, canyon.WithLambdaMiddlewares(
    func(next interface{}) intrerface{} {
        return otellambda.InstrumentHandler(next)
    }
)
 err := canyon.RunWithContext(ctx, "your-sqs-queue-name", http.HandlerFunc(handler), opts...)
///
}
```

## Copilot summary

This pull request introduces middleware support for AWS Lambda functions and refactors the `runWithContext` function to improve its flexibility and maintainability. The most important changes include the addition of middleware handling, updates to the `runOptions` struct, and modifications to the `runWithContext` function to incorporate these changes.

Middleware support for AWS Lambda functions:

* [`option.go`](diffhunk://#diff-086a37ef11c8fd9a2516991339db79c207741ac98dd89c8215d31a8bead2814fR75): Added a new field `lambdaMiddlewares` to the `runOptions` struct to store middleware functions.
* [`option.go`](diffhunk://#diff-086a37ef11c8fd9a2516991339db79c207741ac98dd89c8215d31a8bead2814fR549-R556): Introduced a new function `WithLambdaMiddlewares` to set the lambda middlewares in the `runOptions` struct.

Refactoring `runWithContext` function:

* [`canyon.go`](diffhunk://#diff-b99c15714a74951e9a59c450b17a23f459e8fc49fc4afed4a0cc787007889db2L79-R80): Refactored the `runWithContext` function to use a variable `lambdaHandler` for the lambda function handler and applied the middlewares to it before starting the lambda function. [[1]](diffhunk://#diff-b99c15714a74951e9a59c450b17a23f459e8fc49fc4afed4a0cc787007889db2L79-R80) [[2]](diffhunk://#diff-b99c15714a74951e9a59c450b17a23f459e8fc49fc4afed4a0cc787007889db2L127-R131)