### PR TITLE
Add UsedFromContext and IsWorkerFromContext

### DIFF
--- a/context.go
+++ b/context.go
@@ -138,6 +138,12 @@ func IsWorker(r *http.Request) bool {
 	return isWorker
 }
 
+// IsWorkerFromContext returns true if the request is from worker.
+func IsWorkerFromContext(ctx context.Context) bool {
+	isWorker, ok := ctx.Value(contextKeyIsWorker).(bool)
+	return ok && isWorker
+}
+
 // Used return true if the request handled by canyon.
 func Used(r *http.Request) bool {
 	ctx := r.Context()
@@ -148,6 +154,14 @@ func Used(r *http.Request) bool {
 		return true
 	}
 	return IsWorker(r)
+}
+
+// UsedFromContext returns true if the request handled by canyon.
+func UsedFromContext(ctx context.Context) bool {
+	if _, ok := ctx.Value(contextKeyWorkerSender).(WorkerSender); ok {
+		return true
+	}
+	return IsWorkerFromContext(ctx)
 }
 
 // EmbedIsWorkerInContext embeds isWorker flag in context.


### PR DESCRIPTION
This pull request includes changes to the `context.go` file to add new functions that check if a request is from a worker or handled by canyon using the context.

New functions added:

* [`IsWorkerFromContext`](diffhunk://#diff-552f47512a00afe5fc6850cc9ddc830a6daeca162750e50aab4ed549685e0253R141-R146): This function checks if a request is from a worker by looking up the `contextKeyIsWorker` value in the context.
* [`UsedFromContext`](diffhunk://#diff-552f47512a00afe5fc6850cc9ddc830a6daeca162750e50aab4ed549685e0253R159-R166): This function checks if a request is handled by canyon by looking up the `contextKeyWorkerSender` value in the context and also calls `IsWorkerFromContext` if needed.