### PR TITLE
Feature/streaming response

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -15,7 +15,11 @@ linters:
       exclude-functions:
         - "fmt.Fprintln"
         - "fmt.Fprintf"
+        - "fmt.Fprint"
         - "io.WriteString"
+        - "io.Copy"
+        - "(io.Closer).Close"
+        - "os.Setenv"
         - "(io.ReadCloser).Close"
         - "(*bytes.Buffer).Write"
         - "(*bytes.Buffer).WriteString"
@@ -23,7 +27,9 @@ linters:
         - "(net/http.ResponseWriter).Write"
         - "(*os.File).Close"
         - "github.com/mashiike/canyon.RunWithContext"
+        - (*github.com/mashiike/canyon/canyontest.Runner).Close
         - "(*encoding/json.Encoder).Encode"
+        - "(net.Listener).Close"
     revive:
       max-open-files: 2048
       rules:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -30,6 +30,8 @@ linters:
         - (*github.com/mashiike/canyon/canyontest.Runner).Close
         - "(*encoding/json.Encoder).Encode"
         - "(net.Listener).Close"
+        - "(*net/http.Server).Shutdown"
+        - "(*io.PipeWriter).Write"
     revive:
       max-open-files: 2048
       rules:

--- a/aws.go
+++ b/aws.go
@@ -177,14 +177,14 @@ func (svc *sqsLongPollingService) Start(ctx context.Context, fn sqsEventLambdaHa
 		default:
 		}
 		input := &sqs.ReceiveMessageInput{
-			QueueUrl:              aws.String(svc.queueURL),
-			MaxNumberOfMessages:   svc.maxNumberObMessages,
-			WaitTimeSeconds:       svc.waitTimeSeconds,
-			VisibilityTimeout:     int32(visibilityTimeout),
-			AttributeNames:        []types.QueueAttributeName{"All"},
-			MessageAttributeNames: []string{"All"},
+			QueueUrl:                    aws.String(svc.queueURL),
+			MaxNumberOfMessages:         svc.maxNumberObMessages,
+			WaitTimeSeconds:             svc.waitTimeSeconds,
+			VisibilityTimeout:           int32(visibilityTimeout),
+			MessageSystemAttributeNames: []types.MessageSystemAttributeName{"All"},
+			MessageAttributeNames:       []string{"All"},
 		}
-		svc.logger.DebugContext(ctx, "receive message from sqs queue", "queue_url", *input.QueueUrl, "max_number_of_messages", input.MaxNumberOfMessages, "wait_time_seconds", input.WaitTimeSeconds, "visibility_timeout", input.VisibilityTimeout, "attribute_names", input.AttributeNames, "message_attribute_names", input.MessageAttributeNames)
+		svc.logger.DebugContext(ctx, "receive message from sqs queue", "queue_url", *input.QueueUrl, "max_number_of_messages", input.MaxNumberOfMessages, "wait_time_seconds", input.WaitTimeSeconds, "visibility_timeout", input.VisibilityTimeout, "attribute_names", input.MessageSystemAttributeNames, "message_attribute_names", input.MessageAttributeNames)
 		output, err := svc.sqsClient.ReceiveMessage(ctx, input)
 		if err != nil {
 			return err
@@ -768,6 +768,6 @@ func checkFunctionResponseTypes(ctx context.Context, c *runOptions) {
 	}
 }
 
-func isEnableReportBatchItemFailures(ctx context.Context, eventSourceARN string) bool {
+func isEnableReportBatchItemFailures(_ context.Context, eventSourceARN string) bool {
 	return enableReportBatchItemFailures[eventSourceARN]
 }

--- a/canyon.go
+++ b/canyon.go
@@ -776,6 +776,7 @@ func defaultWorkerSender(serializer Serializer, c *runOptions) WorkerSender {
 			}
 			return DelayedSQSMessageID, nil
 		}
+		c.logger.DebugContext(ctx, "send sqs message", "queue_url", queueURL, "delay_seconds", input.DelaySeconds)
 		output, err := client.SendMessage(ctx, input)
 		if err != nil {
 			return "", fmt.Errorf("failed to send sqs message: %w", err)

--- a/canyon.go
+++ b/canyon.go
@@ -331,7 +331,10 @@ func setupHTTPServer(ctx context.Context, serverHandler http.Handler, c *runOpti
 		listener = &proxyproto.Listener{Listener: listener}
 	}
 	srv := http.Server{Handler: m}
+	var wg sync.WaitGroup
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		<-ctx.Done()
 		c.logger.InfoContext(ctx, "shutting down local httpd", "address", c.address)
 		shutdownCtx, timout := context.WithTimeout(context.Background(), 5*time.Second)
@@ -345,6 +348,7 @@ func setupHTTPServer(ctx context.Context, serverHandler http.Handler, c *runOpti
 			return err
 		}
 	}
+	wg.Wait()
 	return nil
 }
 

--- a/canyon.go
+++ b/canyon.go
@@ -72,265 +72,271 @@ func runWithContext(ctx context.Context, mux http.Handler, c *runOptions) error 
 	workerHandler := newWorkerHandler(mux, c)
 	serverHandler := newServerHandler(mux, c)
 	lambdaFallbackHandler := newLambdaFallbackHandler(mux, c)
-	if isLambda() {
-		lambdaOptions := make([]lambda.Option, len(c.lambdaOptions), len(c.lambdaOptions)+1)
-		copy(lambdaOptions, c.lambdaOptions)
-		lambdaOptions = append(lambdaOptions, lambda.WithContext(ctx))
-		lambdaHandler := lambda.NewHandlerWithOptions(func(ctx context.Context, event json.RawMessage) (interface{}, error) {
-			var p eventPayload
-			if err := json.Unmarshal(event, &p); err != nil {
-				if lambdaFallbackHandler != nil {
-					return lambdaFallbackHandler.Invoke(ctx, event)
-				}
-				return nil, err
-			}
-			if p.IsSQSEvent {
-				if len(p.SQSEvent.Records) > 1 {
-					onceCheckFunctionResponseTypes.Do(func() {
-						checkFunctionResponseTypes(ctx, c)
-					})
-				}
 
-				resp, err := workerHandler(ctx, p.SQSEvent)
-				if err != nil {
-					return nil, err
-				}
-				if len(resp.BatchItemFailures) == 0 {
-					return resp, nil
-				}
-				if len(p.SQSEvent.Records) == 1 {
-					return resp, fmt.Errorf("failed processing record(message_id=%s)", p.SQSEvent.Records[0].MessageId)
-				}
-				if !isEnableReportBatchItemFailures(ctx, p.SQSEvent.Records[0].EventSourceARN) {
-					return resp, fmt.Errorf("failed processing %d records", len(resp.BatchItemFailures))
-				}
-				return resp, nil
-			}
-			if p.IsHTTPEvent {
-				r := p.Request.WithContext(ctx)
-				w := ridge.NewResponseWriter()
-				serverHandler.ServeHTTP(w, r)
-				return w.Response(), nil
-			}
-			if p.IsWebsocketProxyEvent {
-				r := p.Request.WithContext(ctx)
-				w := ridge.NewResponseWriter()
-				serverHandler.ServeHTTP(w, r)
-				return w.Response(), nil
-			}
-
-			if lambdaFallbackHandler != nil {
-				return lambdaFallbackHandler.Invoke(ctx, event)
-			}
-			return nil, errors.New("unsupported event")
-		}, lambdaOptions...)
-		for _, middleware := range c.lambdaMiddlewares {
-			lambdaHandler = middleware(lambdaHandler)
-		}
-		lambda.Start(lambdaHandler)
-		return nil
-	}
-	if c.useInMemorySQS {
-		c.logger.Info("enable in memory queue", "visibility_timeout", c.inMemorySQSClientVisibilityTimeout.String(), "max_receive_count", c.inMemorySQSClientMaxReceiveCount)
-		fakeClient := &inMemorySQSClient{
-			visibilityTimeout: c.inMemorySQSClientVisibilityTimeout,
-			maxReceiveCount:   int(c.inMemorySQSClientMaxReceiveCount),
-			dlq:               json.NewEncoder(c.inMemorySQSClientDLQ),
-		}
-		if c.logVarbose {
-			fakeClient.logger = c.logger.With(LogComponentAttributeKey, "fake_sqs")
-		}
-		c.sqsClient = fakeClient
+	if OnLambdaRuntime() {
+		return setupLambdaHandler(ctx, workerHandler, serverHandler, lambdaFallbackHandler, c)
 	}
 
+	var wg sync.WaitGroup
 	var mu sync.Mutex
 	var errs []error
-	var wg sync.WaitGroup
 	cctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	if !c.disableServer {
-		m := http.NewServeMux()
-		switch {
-		case c.prefix == "/", c.prefix == "":
-			m.Handle("/", serverHandler)
-		case !strings.HasSuffix(c.prefix, "/"):
-			m.Handle(c.prefix+"/", http.StripPrefix(c.prefix, serverHandler))
-		default:
-			m.Handle(c.prefix, http.StripPrefix(strings.TrimSuffix(c.prefix, "/"), serverHandler))
-		}
-		var listener net.Listener
-		if c.listener == nil {
-			var err error
-			c.logger.InfoContext(ctx, "starting up with local httpd", "address", c.address)
-			listener, err = net.Listen("tcp", c.address)
-			if err != nil {
-				return fmt.Errorf("couldn't listen to %s: %s", c.address, err.Error())
 
-			}
-		} else {
-			listener = c.listener
-			c.address = listener.Addr().String()
-			c.logger.InfoContext(ctx, "starting up with local httpd", "address", listener.Addr().String())
-		}
-		if c.proxyProtocol {
-			c.logger.InfoContext(ctx, "enables to PROXY protocol")
-			listener = &proxyproto.Listener{Listener: listener}
-		}
-		srv := http.Server{Handler: m}
-		wg.Add(2)
-		go func() {
-			defer wg.Done()
-			<-cctx.Done()
-			c.logger.InfoContext(cctx, "shutting down local httpd", "address", c.address)
-			shutdownCtx, timout := context.WithTimeout(context.Background(), 5*time.Second)
-			defer timout()
-			srv.Shutdown(shutdownCtx)
-		}()
-		go func() {
-			defer wg.Done()
-			if err := srv.Serve(listener); err != nil {
-				if !errors.Is(err, http.ErrServerClosed) && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
-					c.DebugContextWhenVarbose(cctx, "failed to start local httpd", "error", err)
-					mu.Lock()
-					errs = append(errs, err)
-					mu.Unlock()
-					cancel()
-				}
-			}
-		}()
-	}
-	if !c.disableWorker {
+	if !c.disableServer {
 		wg.Add(1)
 		go func() {
-			defer func() {
-				c.logger.InfoContext(cctx, "shutting down sqs poller", "queue", c.sqsQueueName)
-				wg.Done()
-			}()
-			queueURL, client := c.SQSClientAndQueueURL()
-			c.logger.InfoContext(cctx, "staring polling sqs queue", "queue", c.sqsQueueName, "on_memory_queue_mode", c.useInMemorySQS)
-			poller := &sqsLongPollingService{
-				sqsClient:           client,
-				queueURL:            queueURL,
-				maxNumberObMessages: int32(c.batchSize),
-				waitTimeSeconds:     int32(c.pollingDuration.Seconds()),
-				maxDeleteRetry:      3,
-			}
-			if c.logVarbose {
-				poller.logger = c.logger.With(LogComponentAttributeKey, "sqs_poller")
-			}
-			if err := poller.Start(cctx, workerHandler); err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
-				c.DebugContextWhenVarbose(cctx, "failed to start sqs poller", "error", err)
+			defer wg.Done()
+			if err := setupHTTPServer(cctx, serverHandler, c, cancel); err != nil {
 				mu.Lock()
 				errs = append(errs, err)
 				mu.Unlock()
-				cancel()
 			}
 		}()
 	}
+
+	if !c.disableWorker {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := setupSQSPoller(cctx, workerHandler, c, cancel); err != nil {
+				mu.Lock()
+				errs = append(errs, err)
+				mu.Unlock()
+			}
+		}()
+	}
+
 	if !c.disableWebsocket && (c.websocketListener != nil || c.websocketAddress != "") {
-		var websocketListener net.Listener
-		if c.websocketListener == nil {
-			var err error
-			c.logger.InfoContext(ctx, "starting up with local websocket server", "address", c.websocketAddress)
-			websocketListener, err = net.Listen("tcp", c.websocketAddress)
-			if err != nil {
-				return fmt.Errorf("couldn't listen to %s: %s", c.address, err.Error())
-			}
-		} else {
-			websocketListener = c.websocketListener
-			c.websocketAddress = websocketListener.Addr().String()
-			c.logger.InfoContext(ctx, "starting up with local websocket server", "address", websocketListener.Addr().String())
-		}
-		if c.websocketCallbackURL == "" {
-			c.websocketCallbackURL = fmt.Sprintf("http://%s", c.websocketAddress)
-		}
-		bridgeHandler := NewWebsocketHTTPBridgeHandler(serverHandler)
-		wsSrv := http.Server{Handler: bridgeHandler}
-		wg.Add(2)
+		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			<-cctx.Done()
-			c.logger.InfoContext(cctx, "shutting down local websocket server", "address", c.address)
-			shutdownCtx, timout := context.WithTimeout(context.Background(), 5*time.Second)
-			defer timout()
-			wsSrv.Shutdown(shutdownCtx)
-		}()
-		go func() {
-			defer wg.Done()
-			if err := wsSrv.Serve(websocketListener); err != nil {
-				if !errors.Is(err, http.ErrServerClosed) && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
-					c.DebugContextWhenVarbose(cctx, "failed to start local websocket server", "error", err)
-					mu.Lock()
-					errs = append(errs, err)
-					mu.Unlock()
-					cancel()
-				}
+			if err := setupWebSocketServer(cctx, serverHandler, c, cancel); err != nil {
+				mu.Lock()
+				errs = append(errs, err)
+				mu.Unlock()
 			}
 		}()
 	}
+
 	if lambdaFallbackHandler != nil {
 		wg.Add(1)
 		go func() {
-			defer func() {
-				c.logger.InfoContext(cctx, "shutting down fallback lambda handler")
-				wg.Done()
-			}()
-			c.logger.InfoContext(cctx, "staring fallback lambda handler, bypassing from stdin")
-			decoder := jsonx.NewDecoder(c.stdin)
-			for decoder.MoreWithContext(ctx) {
-				var event json.RawMessage
-				if err := decoder.DecodeWithContext(ctx, &event); err != nil {
-					var jsonUnmarshalTypeError *json.UnmarshalTypeError
-					var jsonSyntaxError *json.SyntaxError
-					switch {
-					case errors.Is(err, io.EOF),
-						errors.Is(err, context.Canceled),
-						errors.Is(err, context.DeadlineExceeded),
-						errors.Is(err, io.ErrClosedPipe),
-						errors.Is(err, io.ErrUnexpectedEOF):
-						break
-					case
-						errors.As(err, &jsonUnmarshalTypeError),
-						errors.As(err, &jsonSyntaxError):
-						c.WarnContextWhenVarbose(cctx, "failed to decode event from stdin, reset decoder state", "error", err)
-						decoder.SkipUntilValidToken()
-						continue
-					default:
-						c.DebugContextWhenVarbose(cctx, "stop fallback lambda handler", "error", err, "type", fmt.Sprintf("%T", err))
-						mu.Lock()
-						errs = append(errs, err)
-						mu.Unlock()
-					}
-					cancel()
-					return
-				}
-				if _, err := lambdaFallbackHandler.Invoke(cctx, event); err != nil {
-					if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
-						c.DebugContextWhenVarbose(cctx, "failed to invoke fallback lambda handler", "error", err)
-						mu.Lock()
-						errs = append(errs, err)
-						mu.Unlock()
-						cancel()
-					}
-					return
-				}
+			defer wg.Done()
+			if err := setupFallbackLambdaHandler(cctx, lambdaFallbackHandler, c, cancel); err != nil {
+				mu.Lock()
+				errs = append(errs, err)
+				mu.Unlock()
 			}
 		}()
 	}
+
 	wg.Wait()
-	errCtxCarsed := context.Cause(ctx)
+
 	if len(errs) > 0 {
-		if errCtxCarsed != nil {
-			for _, err := range errs {
-				if errors.Is(err, errCtxCarsed) {
-					return errors.Join(errs...)
-				}
-			}
-			errs = append(errs, errCtxCarsed)
-		}
 		return errors.Join(errs...)
 	}
-	return errCtxCarsed
+	return context.Cause(ctx)
+}
+
+func setupLambdaHandler(ctx context.Context, workerHandler sqsEventLambdaHandlerFunc, serverHandler http.Handler, lambdaFallbackHandler lambda.Handler, c *runOptions) error {
+	lambdaOptions := make([]lambda.Option, len(c.lambdaOptions), len(c.lambdaOptions)+1)
+	copy(lambdaOptions, c.lambdaOptions)
+	lambdaOptions = append(lambdaOptions, lambda.WithContext(ctx))
+	lambdaHandler := lambda.NewHandlerWithOptions(func(ctx context.Context, event json.RawMessage) (interface{}, error) {
+		var p eventPayload
+		if err := json.Unmarshal(event, &p); err != nil {
+			if lambdaFallbackHandler != nil {
+				return lambdaFallbackHandler.Invoke(ctx, event)
+			}
+			return nil, err
+		}
+		if p.IsSQSEvent {
+			if len(p.SQSEvent.Records) > 1 {
+				onceCheckFunctionResponseTypes.Do(func() {
+					checkFunctionResponseTypes(ctx, c)
+				})
+			}
+
+			resp, err := workerHandler(ctx, p.SQSEvent)
+			if err != nil {
+				return nil, err
+			}
+			if len(resp.BatchItemFailures) == 0 {
+				return resp, nil
+			}
+			if len(p.SQSEvent.Records) == 1 {
+				return resp, fmt.Errorf("failed processing record(message_id=%s)", p.SQSEvent.Records[0].MessageId)
+			}
+			if !isEnableReportBatchItemFailures(ctx, p.SQSEvent.Records[0].EventSourceARN) {
+				return resp, fmt.Errorf("failed processing %d records", len(resp.BatchItemFailures))
+			}
+			return resp, nil
+		}
+		if p.IsHTTPEvent {
+			r := p.Request.WithContext(ctx)
+			w := ridge.NewResponseWriter()
+			serverHandler.ServeHTTP(w, r)
+			return w.Response(), nil
+		}
+		if p.IsWebsocketProxyEvent {
+			r := p.Request.WithContext(ctx)
+			w := ridge.NewResponseWriter()
+			serverHandler.ServeHTTP(w, r)
+			return w.Response(), nil
+		}
+
+		if lambdaFallbackHandler != nil {
+			return lambdaFallbackHandler.Invoke(ctx, event)
+		}
+		return nil, errors.New("unsupported event")
+	}, lambdaOptions...)
+	for _, middleware := range c.lambdaMiddlewares {
+		lambdaHandler = middleware(lambdaHandler)
+	}
+	lambda.Start(lambdaHandler)
+	return nil
+}
+
+func setupHTTPServer(ctx context.Context, serverHandler http.Handler, c *runOptions, cancel context.CancelFunc) error {
+	m := http.NewServeMux()
+	switch {
+	case c.prefix == "/", c.prefix == "":
+		m.Handle("/", serverHandler)
+	case !strings.HasSuffix(c.prefix, "/"):
+		m.Handle(c.prefix+"/", http.StripPrefix(c.prefix, serverHandler))
+	default:
+		m.Handle(c.prefix, http.StripPrefix(strings.TrimSuffix(c.prefix, "/"), serverHandler))
+	}
+	var listener net.Listener
+	if c.listener == nil {
+		var err error
+		c.logger.InfoContext(ctx, "starting up with local httpd", "address", c.address)
+		listener, err = net.Listen("tcp", c.address)
+		if err != nil {
+			return fmt.Errorf("couldn't listen to %s: %s", c.address, err.Error())
+		}
+	} else {
+		listener = c.listener
+		c.address = listener.Addr().String()
+		c.logger.InfoContext(ctx, "starting up with local httpd", "address", listener.Addr().String())
+	}
+	if c.proxyProtocol {
+		c.logger.InfoContext(ctx, "enables to PROXY protocol")
+		listener = &proxyproto.Listener{Listener: listener}
+	}
+	srv := http.Server{Handler: m}
+	go func() {
+		<-ctx.Done()
+		c.logger.InfoContext(ctx, "shutting down local httpd", "address", c.address)
+		shutdownCtx, timout := context.WithTimeout(context.Background(), 5*time.Second)
+		defer timout()
+		srv.Shutdown(shutdownCtx)
+	}()
+	if err := srv.Serve(listener); err != nil {
+		if !errors.Is(err, http.ErrServerClosed) && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			c.DebugContextWhenVarbose(ctx, "failed to start local httpd", "error", err)
+			cancel()
+			return err
+		}
+	}
+	return nil
+}
+
+func setupSQSPoller(ctx context.Context, workerHandler sqsEventLambdaHandlerFunc, c *runOptions, cancel context.CancelFunc) error {
+	queueURL, client := c.SQSClientAndQueueURL()
+	c.logger.InfoContext(ctx, "staring polling sqs queue", "queue", c.sqsQueueName, "on_memory_queue_mode", c.useInMemorySQS)
+	poller := &sqsLongPollingService{
+		sqsClient:           client,
+		queueURL:            queueURL,
+		maxNumberObMessages: int32(c.batchSize),
+		waitTimeSeconds:     int32(c.pollingDuration.Seconds()),
+		maxDeleteRetry:      3,
+	}
+	if c.logVarbose {
+		poller.logger = c.logger.With(LogComponentAttributeKey, "sqs_poller")
+	}
+	if err := poller.Start(ctx, workerHandler); err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+		c.DebugContextWhenVarbose(ctx, "failed to start sqs poller", "error", err)
+		cancel()
+		return err
+	}
+	return nil
+}
+
+func setupWebSocketServer(ctx context.Context, serverHandler http.Handler, c *runOptions, cancel context.CancelFunc) error {
+	var websocketListener net.Listener
+	if c.websocketListener == nil {
+		var err error
+		c.logger.InfoContext(ctx, "starting up with local websocket server", "address", c.websocketAddress)
+		websocketListener, err = net.Listen("tcp", c.websocketAddress)
+		if err != nil {
+			return fmt.Errorf("couldn't listen to %s: %s", c.address, err.Error())
+		}
+	} else {
+		websocketListener = c.websocketListener
+		c.websocketAddress = websocketListener.Addr().String()
+		c.logger.InfoContext(ctx, "starting up with local websocket server", "address", websocketListener.Addr().String())
+	}
+	if c.websocketCallbackURL == "" {
+		c.websocketCallbackURL = fmt.Sprintf("http://%s", c.websocketAddress)
+	}
+	bridgeHandler := NewWebsocketHTTPBridgeHandler(serverHandler)
+	wsSrv := http.Server{Handler: bridgeHandler}
+	go func() {
+		<-ctx.Done()
+		c.logger.InfoContext(ctx, "shutting down local websocket server", "address", c.address)
+		shutdownCtx, timout := context.WithTimeout(context.Background(), 5*time.Second)
+		defer timout()
+		wsSrv.Shutdown(shutdownCtx)
+	}()
+	if err := wsSrv.Serve(websocketListener); err != nil {
+		if !errors.Is(err, http.ErrServerClosed) && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			c.DebugContextWhenVarbose(ctx, "failed to start local websocket server", "error", err)
+			cancel()
+			return err
+		}
+	}
+	return nil
+}
+
+func setupFallbackLambdaHandler(ctx context.Context, lambdaFallbackHandler lambda.Handler, c *runOptions, cancel context.CancelFunc) error {
+	c.logger.InfoContext(ctx, "staring fallback lambda handler, bypassing from stdin")
+	decoder := jsonx.NewDecoder(c.stdin)
+	for decoder.MoreWithContext(ctx) {
+		var event json.RawMessage
+		if err := decoder.DecodeWithContext(ctx, &event); err != nil {
+			var jsonUnmarshalTypeError *json.UnmarshalTypeError
+			var jsonSyntaxError *json.SyntaxError
+			switch {
+			case errors.Is(err, io.EOF),
+				errors.Is(err, context.Canceled),
+				errors.Is(err, context.DeadlineExceeded),
+				errors.Is(err, io.ErrClosedPipe),
+				errors.Is(err, io.ErrUnexpectedEOF):
+				break
+			case
+				errors.As(err, &jsonUnmarshalTypeError),
+				errors.As(err, &jsonSyntaxError):
+				c.WarnContextWhenVarbose(ctx, "failed to decode event from stdin, reset decoder state", "error", err)
+				decoder.SkipUntilValidToken()
+				continue
+			default:
+				c.DebugContextWhenVarbose(ctx, "stop fallback lambda handler", "error", err, "type", fmt.Sprintf("%T", err))
+				cancel()
+				return err
+			}
+		}
+		if _, err := lambdaFallbackHandler.Invoke(ctx, event); err != nil {
+			if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+				c.DebugContextWhenVarbose(ctx, "failed to invoke fallback lambda handler", "error", err)
+				cancel()
+				return err
+			}
+			return nil
+		}
+	}
+	return nil
 }
 
 // WorkerResponseWriter is a http.ResponseWriter for worker handler.
@@ -381,7 +387,8 @@ func newWorkerHandler(mux http.Handler, c *runOptions) sqsEventLambdaHandlerFunc
 	if s, ok := serializer.(LoggingableSerializer); ok && c.logVarbose {
 		serializer = s.WithLogger(logger)
 	}
-	wraped := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+	wrappedHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		if client, err := NewManagementAPIClientWithRequest(r, c.websocketCallbackURL); err == nil {
 			ctx = EmbedWebsocketManagementAPIClient(ctx, client)
@@ -390,146 +397,155 @@ func newWorkerHandler(mux http.Handler, c *runOptions) sqsEventLambdaHandlerFunc
 		}
 		mux.ServeHTTP(w, r.WithContext(ctx))
 	})
+	visibilityTimeout, sqsClient := initializeSQSClient(c, logger)
+
+	return func(ctx context.Context, event *events.SQSEvent) (*events.SQSEventResponse, error) {
+		return processSQSEvent(ctx, event, wrappedHandler, serializer, c, logger, visibilityTimeout, sqsClient)
+	}
+}
+
+func initializeSQSClient(c *runOptions, _ *slog.Logger) (time.Duration, SQSClient) {
 	var once sync.Once
 	var visibilityTimeout time.Duration = -1 * time.Second
 	var sqsClient SQSClient
-	return func(ctx context.Context, event *events.SQSEvent) (*events.SQSEventResponse, error) {
-		once.Do(func() {
-			queueURL, client := c.SQSClientAndQueueURL()
-			sqsClient = client
-			vt, err := getVisibilityTimeout(ctx, queueURL, client)
-			if err != nil {
-				var ae smithy.APIError
-				if !errors.As(err, &ae) {
-					c.cancel(err)
-					return
-				}
-				if ae.ErrorCode() != "AccessDeniedException" {
-					return
-				}
+
+	once.Do(func() {
+		queueURL, client := c.SQSClientAndQueueURL()
+		sqsClient = client
+		vt, err := getVisibilityTimeout(context.Background(), queueURL, client)
+		if err != nil {
+			var ae smithy.APIError
+			if !errors.As(err, &ae) || ae.ErrorCode() != "AccessDeniedException" {
+				c.cancel(err)
 			}
+		} else {
 			visibilityTimeout = time.Duration(vt) * time.Second
+		}
+	})
+
+	return visibilityTimeout, sqsClient
+}
+
+func processSQSEvent(
+	ctx context.Context,
+	event *events.SQSEvent,
+	wrappedHandler http.Handler,
+	serializer Serializer,
+	c *runOptions,
+	logger *slog.Logger,
+	visibilityTimeout time.Duration,
+	sqsClient SQSClient,
+) (*events.SQSEventResponse, error) {
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	var resp events.SQSEventResponse
+
+	if visibilityTimeout > c.workerTimeoutMergin {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, visibilityTimeout-c.workerTimeoutMergin)
+		defer cancel()
+	}
+
+	messageIds := make([]string, 0, len(event.Records))
+	completed := make(map[string]bool, len(event.Records))
+	changeMessageVisibilityBatchInput := &sqs.ChangeMessageVisibilityBatchInput{
+		QueueUrl: aws.String(c.sqsQueueURL),
+	}
+
+	onFailure := func(record events.SQSMessage) {
+		mu.Lock()
+		defer mu.Unlock()
+		resp.BatchItemFailures = append(resp.BatchItemFailures, events.SQSBatchItemFailure{
+			ItemIdentifier: record.MessageId,
 		})
-		var mu sync.Mutex
-		var wg sync.WaitGroup
-		var resp events.SQSEventResponse
-		if visibilityTimeout > c.workerTimeoutMergin {
-			var cancel context.CancelFunc
-			ctx, cancel = context.WithTimeout(ctx, visibilityTimeout-c.workerTimeoutMergin)
-			defer cancel()
-		}
-		messageIds := make([]string, 0, len(event.Records))
-		completed := make(map[string]bool, len(event.Records))
-		changeMessageVisibilityBatchInput := &sqs.ChangeMessageVisibilityBatchInput{
-			QueueUrl: aws.String(c.sqsQueueURL),
-		}
-		onFailure := func(record events.SQSMessage) {
-			mu.Lock()
-			defer mu.Unlock()
-			resp.BatchItemFailures = append(resp.BatchItemFailures, events.SQSBatchItemFailure{
-				ItemIdentifier: record.MessageId,
-			})
-			completed[record.MessageId] = true
-		}
-		onSuccess := func(record events.SQSMessage) {
-			mu.Lock()
-			defer mu.Unlock()
-			completed[record.MessageId] = true
-		}
-		setRetryAfter := func(record *events.SQSMessage, retryAfterSeconds int32) {
-			mu.Lock()
-			defer mu.Unlock()
-			changeMessageVisibilityBatchInput.Entries = append(
-				changeMessageVisibilityBatchInput.Entries,
-				types.ChangeMessageVisibilityBatchRequestEntry{
-					Id:                aws.String(record.MessageId),
-					ReceiptHandle:     aws.String(record.ReceiptHandle),
-					VisibilityTimeout: retryAfterSeconds, // after adding current visibility timeout
-				},
-			)
-		}
-		for _, record := range event.Records {
-			wg.Add(1)
-			_logger := logger.With(slog.String("message_id", record.MessageId))
-			messageIds = append(messageIds, record.MessageId)
-			go func(record events.SQSMessage) {
-				defer wg.Done()
-				w := NewWorkerResponseWriter()
-				r, err := serializer.Deserialize(ctx, &record)
-				if err != nil {
-					_logger.ErrorContext(
-						ctx,
-						"failed to restore request from sqs message",
-						"error", err,
-					)
-					onFailure(record)
-					retryAfter, ok := ErrorHasRetryAfter(err)
-					if !ok {
-						return
-					}
+		completed[record.MessageId] = true
+	}
+
+	onSuccess := func(record events.SQSMessage) {
+		mu.Lock()
+		defer mu.Unlock()
+		completed[record.MessageId] = true
+	}
+
+	setRetryAfter := func(record *events.SQSMessage, retryAfterSeconds int32) {
+		mu.Lock()
+		defer mu.Unlock()
+		changeMessageVisibilityBatchInput.Entries = append(
+			changeMessageVisibilityBatchInput.Entries,
+			types.ChangeMessageVisibilityBatchRequestEntry{
+				Id:                aws.String(record.MessageId),
+				ReceiptHandle:     aws.String(record.ReceiptHandle),
+				VisibilityTimeout: retryAfterSeconds,
+			},
+		)
+	}
+
+	for _, record := range event.Records {
+		wg.Add(1)
+		_logger := logger.With(slog.String("message_id", record.MessageId))
+		messageIds = append(messageIds, record.MessageId)
+		go func(record events.SQSMessage) {
+			defer wg.Done()
+			w := NewWorkerResponseWriter()
+			r, err := serializer.Deserialize(ctx, &record)
+			if err != nil {
+				_logger.ErrorContext(ctx, "failed to restore request from sqs message", "error", err)
+				onFailure(record)
+				if retryAfter, ok := ErrorHasRetryAfter(err); ok {
 					setRetryAfter(&record, retryAfter)
-					return
 				}
-				embededCtx := EmbedIsWorkerInContext(ctx, true)
-				embededCtx = embedLoggerInContext(embededCtx, _logger)
-				wraped.ServeHTTP(w, r.WithContext(embededCtx))
-				workerResp := w.Response(r)
-				if c.responseChecker.IsFailure(ctx, workerResp) {
-					_logger.ErrorContext(
-						ctx,
-						"failed worker handler",
-						"status_code", w.statusCode,
-					)
-					onFailure(record)
-					retryAfter := workerResp.Header.Get("Retry-After")
-					if retryAfter == "" {
-						return
+				return
+			}
+			embededCtx := EmbedIsWorkerInContext(ctx, true)
+			embededCtx = embedLoggerInContext(embededCtx, _logger)
+			wrappedHandler.ServeHTTP(w, r.WithContext(embededCtx))
+			workerResp := w.Response(r)
+			if c.responseChecker.IsFailure(ctx, workerResp) {
+				_logger.ErrorContext(ctx, "failed worker handler", "status_code", w.statusCode)
+				onFailure(record)
+				if retryAfter := workerResp.Header.Get("Retry-After"); retryAfter != "" {
+					if retryAfterSeconds, err := strconv.ParseInt(retryAfter, 10, 32); err == nil {
+						setRetryAfter(&record, int32(retryAfterSeconds))
+					} else {
+						_logger.WarnContext(ctx, "failed to parse Retry-After header", "error", err, "retry_after", retryAfter)
 					}
-					retryAfterSeconds, err := strconv.ParseInt(retryAfter, 10, 32)
-					if err != nil {
-						_logger.WarnContext(
-							ctx,
-							"failed to parse Retry-After header",
-							"error", err,
-							"retry_after", retryAfter,
-						)
-						return
-					}
-					setRetryAfter(&record, int32(retryAfterSeconds))
-					return
 				}
-				onSuccess(record)
-			}(record)
-		}
-		allDone := make(chan struct{})
-		go func() {
-			wg.Wait()
-			close(allDone)
-		}()
-		select {
-		case <-allDone:
-		case <-ctx.Done():
-			if errors.Is(ctx.Err(), context.DeadlineExceeded) || errors.Is(ctx.Err(), context.Canceled) {
-				logger.WarnContext(ctx, "worker timeout exceeded", "timeout", visibilityTimeout)
-				mu.Lock()
-				for _, id := range messageIds {
-					if completed[id] {
-						continue
-					}
+				return
+			}
+			onSuccess(record)
+		}(record)
+	}
+
+	allDone := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(allDone)
+	}()
+
+	select {
+	case <-allDone:
+	case <-ctx.Done():
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) || errors.Is(ctx.Err(), context.Canceled) {
+			logger.WarnContext(ctx, "worker timeout exceeded", "timeout", visibilityTimeout)
+			mu.Lock()
+			for _, id := range messageIds {
+				if !completed[id] {
 					resp.BatchItemFailures = append(resp.BatchItemFailures, events.SQSBatchItemFailure{
 						ItemIdentifier: id,
 					})
 				}
-				mu.Unlock()
 			}
+			mu.Unlock()
 		}
-		if len(changeMessageVisibilityBatchInput.Entries) > 0 {
-			if _, err := sqsClient.ChangeMessageVisibilityBatch(ctx, changeMessageVisibilityBatchInput); err != nil {
-				logger.WarnContext(ctx, "failed to change message visibility", "error", err)
-			}
-		}
-		return &resp, nil
 	}
+
+	if len(changeMessageVisibilityBatchInput.Entries) > 0 {
+		if _, err := sqsClient.ChangeMessageVisibilityBatch(ctx, changeMessageVisibilityBatchInput); err != nil {
+			logger.WarnContext(ctx, "failed to change message visibility", "error", err)
+		}
+	}
+
+	return &resp, nil
 }
 
 func newServerHandler(mux http.Handler, c *runOptions) http.Handler {
@@ -555,7 +571,11 @@ func newServerHandler(mux http.Handler, c *runOptions) http.Handler {
 			http.Error(w, "internal server error", http.StatusInternalServerError)
 			return
 		}
-		defer closer()
+		defer func() {
+			if err := closer(); err != nil {
+				logger.ErrorContext(ctx, "failed to close backup request", "error", err)
+			}
+		}()
 		mux.ServeHTTP(w, cloned)
 	})
 }
@@ -589,7 +609,7 @@ func newLambdaFallbackHandler(mux http.Handler, c *runOptions) lambda.Handler {
 const DelayedSQSMessageID = "<delayed sqs message>"
 
 func newWorkerSender(mux http.Handler, serializer Serializer, c *runOptions) WorkerSender {
-	if isLambda() && c.useInMemorySQS {
+	if c.useInMemorySQS && OnLambdaRuntime() {
 		return WorkerSenderFunc(func(r *http.Request, opts *SendOptions) (string, error) {
 			// recoall mux as worker
 			ctx := EmbedIsWorkerInContext(r.Context(), true)
@@ -601,63 +621,61 @@ func newWorkerSender(mux http.Handler, serializer Serializer, c *runOptions) Wor
 			}
 			return "in-memory-message", nil
 		})
-	} else {
-		return WorkerSenderFunc(func(r *http.Request, opts *SendOptions) (string, error) {
-			queueURL, client := c.SQSClientAndQueueURL()
-			l := Logger(r)
-			if c.logVarbose {
-				l.DebugContext(r.Context(), "try sqs send message with http request", "method", r.Method, "path", r.URL.Path)
-			}
-			ctx := r.Context()
-			input, err := serializer.Serialize(ctx, RestoreRequest(r))
-			if err != nil {
-				return "", fmt.Errorf("failed to serialize request: %w", err)
-			}
-			input.QueueUrl = aws.String(queueURL)
-			if opts != nil {
-				if len(opts.MessageAttributes) > 0 {
-					if input.MessageAttributes == nil {
-						input.MessageAttributes = make(map[string]types.MessageAttributeValue)
-					}
-					for k, v := range opts.MessageAttributes {
-						input.MessageAttributes[k] = types.MessageAttributeValue{
-							DataType:         aws.String(v.DataType),
-							StringValue:      v.StringValue,
-							BinaryValue:      v.BinaryValue,
-							StringListValues: v.StringListValues,
-							BinaryListValues: v.BinaryListValues,
-						}
-					}
-				}
-				if opts.MessageGroupID != nil {
-					input.MessageGroupId = opts.MessageGroupID
-				}
-				if opts.DelaySeconds != nil {
-					input.DelaySeconds = *opts.DelaySeconds
-				}
-			}
-			// https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessage.html#SQS-SendMessage-request-DelaySeconds
-			// > Valid values: 0 to 900. Maximum: 15 minutes.
-			if input.DelaySeconds < 0 {
-				input.DelaySeconds = 0
-			}
-			if input.DelaySeconds > 900 {
-				if c.scheduler == nil {
-					return "", fmt.Errorf("delay_seconds is too long: if need long delay, scheduler is required")
-				}
-				if err := c.scheduler.RegisterSchedule(ctx, input); err != nil {
-					return "", fmt.Errorf("failed to register to scheduler: %w", err)
-				}
-				return DelayedSQSMessageID, nil
-			}
-			output, err := client.SendMessage(ctx, input)
-			if err != nil {
-				return "", fmt.Errorf("failed to send sqs message: %w", err)
-			}
-			if c.logVarbose {
-				l.DebugContext(r.Context(), "success sqs message sent with http request", "message_id", *output.MessageId, "queue", c.sqsQueueName)
-			}
-			return *output.MessageId, nil
-		})
 	}
+	return defaultWorkerSender(serializer, c)
+}
+
+func defaultWorkerSender(serializer Serializer, c *runOptions) WorkerSender {
+	return WorkerSenderFunc(func(r *http.Request, opts *SendOptions) (string, error) {
+		queueURL, client := c.SQSClientAndQueueURL()
+		ctx := r.Context()
+		c.DebugContextWhenVarbose(ctx, "try sqs send message with http request", "method", r.Method, "path", r.URL.Path)
+		input, err := serializer.Serialize(ctx, RestoreRequest(r))
+		if err != nil {
+			return "", fmt.Errorf("failed to serialize request: %w", err)
+		}
+		input.QueueUrl = aws.String(queueURL)
+		if opts != nil {
+			if len(opts.MessageAttributes) > 0 {
+				if input.MessageAttributes == nil {
+					input.MessageAttributes = make(map[string]types.MessageAttributeValue)
+				}
+				for k, v := range opts.MessageAttributes {
+					input.MessageAttributes[k] = types.MessageAttributeValue{
+						DataType:         aws.String(v.DataType),
+						StringValue:      v.StringValue,
+						BinaryValue:      v.BinaryValue,
+						StringListValues: v.StringListValues,
+						BinaryListValues: v.BinaryListValues,
+					}
+				}
+			}
+			if opts.MessageGroupID != nil {
+				input.MessageGroupId = opts.MessageGroupID
+			}
+			if opts.DelaySeconds != nil {
+				input.DelaySeconds = *opts.DelaySeconds
+			}
+		}
+		// https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessage.html#SQS-SendMessage-request-DelaySeconds
+		// > Valid values: 0 to 900. Maximum: 15 minutes.
+		if input.DelaySeconds < 0 {
+			input.DelaySeconds = 0
+		}
+		if input.DelaySeconds > 900 {
+			if c.scheduler == nil {
+				return "", fmt.Errorf("delay_seconds is too long: if need long delay, scheduler is required")
+			}
+			if err := c.scheduler.RegisterSchedule(ctx, input); err != nil {
+				return "", fmt.Errorf("failed to register to scheduler: %w", err)
+			}
+			return DelayedSQSMessageID, nil
+		}
+		output, err := client.SendMessage(ctx, input)
+		if err != nil {
+			return "", fmt.Errorf("failed to send sqs message: %w", err)
+		}
+		c.DebugContextWhenVarbose(ctx, "success sqs message sent with http request", "message_id", *output.MessageId, "queue", c.sqsQueueName)
+		return *output.MessageId, nil
+	})
 }

--- a/canyon.go
+++ b/canyon.go
@@ -261,7 +261,7 @@ func (w *httpStramingResponseWriter) Write(b []byte) (int, error) {
 }
 
 func (w *httpStramingResponseWriter) Flush() {
-	w.pipeWriter.Write(w.buffer.Bytes()) //lint:ignore errcheck
+	w.pipeWriter.Write(w.buffer.Bytes())
 	w.buffer.Reset()
 }
 

--- a/context.go
+++ b/context.go
@@ -27,15 +27,19 @@ var (
 // if called by sqs message, component is "worker".
 // if called original http request, component is "server".
 func Logger(r *http.Request) *slog.Logger {
-	ctx := r.Context()
+	logger, _ := loggerFromContext(r.Context())
+	return logger
+}
+
+func loggerFromContext(ctx context.Context) (*slog.Logger, bool) {
 	if ctx == nil {
-		return slog.Default()
+		return slog.Default(), false
 	}
 	logger, ok := ctx.Value(contextKeyLogger).(*slog.Logger)
 	if !ok {
-		return slog.Default()
+		return slog.Default(), false
 	}
-	return logger
+	return logger, true
 }
 
 func embedLoggerInContext(ctx context.Context, logger *slog.Logger) context.Context {

--- a/lambda/config.tf.example
+++ b/lambda/config.tf.example
@@ -3,7 +3,7 @@ provider "aws" {
 }
 
 terraform {
-  required_version = "= 1.5.6"
+  required_version = "= 1.9.8"
 
   required_providers {
     aws = {

--- a/lambda/straming/.lambdaignore
+++ b/lambda/straming/.lambdaignore
@@ -1,0 +1,10 @@
+.gitignore
+Makefile
+*.tf
+.terraform*
+.lambdaignore
+function.json
+function.zip
+.git/*
+canyon_example.zip
+config.tf.example

--- a/lambda/straming/Makefile
+++ b/lambda/straming/Makefile
@@ -1,0 +1,17 @@
+export AWS_ACCOUNT_ID := $(shell aws sts get-caller-identity --query 'Account' --output text)
+.PHONY: clean lambroll/logs lambroll/deploy
+
+bootstrap: *.go
+	GOOS=linux GOARCH=amd64 go build -o bootstrap main.go
+
+clean:
+	rm -f bootstrap
+	rm -f canyon_example_dummy.zip
+
+lambroll/deploy: bootstrap
+	lambroll --log-level debug deploy --function-url function_url.json
+	$(MAKE) clean
+
+lambroll/logs:
+	lambroll logs --follow --format=short
+

--- a/lambda/straming/function.json
+++ b/lambda/straming/function.json
@@ -1,0 +1,21 @@
+{
+  "Description": "Example of canyon https://gitbub.com/mashiike/canyon",
+  "Environment": {
+    "Variables": {
+      "TZ": "Asia/Tokyo",
+      "CANYON_BACKEND_URL": "{{ env `CANYON_S3_BACKEND` }}",
+      "CANYON_BACKEND_SAVE_APP_NAME": "canyon-example",
+      "CANYON_ENV": "production"
+    }
+  },
+  "FunctionName": "canyon-streaming-example",
+  "Handler": "bootstrap",
+  "MemorySize": 128,
+  "Role": "arn:aws:iam::{{ must_env `AWS_ACCOUNT_ID` }}:role/canyon-example",
+  "Runtime": "provided.al2",
+  "Tags": {},
+  "Timeout": 300,
+  "TracingConfig": {
+    "Mode": "PassThrough"
+  }
+}

--- a/lambda/straming/function_url.json
+++ b/lambda/straming/function_url.json
@@ -1,0 +1,6 @@
+{
+  "Config": {
+    "AuthType": "NONE",
+    "InvokeMode": "RESPONSE_STREAM"
+  }
+}

--- a/lambda/straming/main.go
+++ b/lambda/straming/main.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"math/rand"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/mashiike/canyon"
+)
+
+var randReader = rand.New(rand.NewSource(time.Now().UnixNano()))
+
+func main() {
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT, syscall.SIGQUIT)
+	defer cancel()
+	os.Setenv("CANYON_SCHEDULER", "true")
+	opts := []canyon.Option{
+		canyon.WithServerAddress(":8080", "/"),
+		canyon.WithCanyonEnv("CANYON_"), // environment variables prefix
+		canyon.WithLambdaFallbackHandler(func(ctx context.Context, event json.RawMessage) error {
+			slog.Error("non SQS or HTTP event", "event", string(event))
+			return errors.New("invalid lambda payload")
+		}),
+		canyon.WithStreamingResponse(),
+	}
+	err := canyon.RunWithContext(ctx, "canyon-example", http.HandlerFunc(handler), opts...)
+	if err != nil {
+		slog.Error("failed to run canyon", "error", err)
+		os.Exit(1)
+	}
+}
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "Streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("Transfer-Encoding", "chunked")
+	w.WriteHeader(http.StatusOK)
+	// write initial data
+	w.Write([]byte("data: Initial data\n\n"))
+	flusher.Flush()
+	// write data every 1 second
+	for i := 0; i < 10; i++ {
+		time.Sleep(1 * time.Second)
+		w.Write([]byte(fmt.Sprintf("data: %d\n\n", i)))
+		flusher.Flush()
+	}
+	// write final data
+	w.Write([]byte("data: Final data\n\n"))
+	flusher.Flush()
+}

--- a/lambda/straming/main.go
+++ b/lambda/straming/main.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"math/rand"
 	"net/http"
 	"os"
 	"os/signal"
@@ -15,8 +14,6 @@ import (
 
 	"github.com/mashiike/canyon"
 )
-
-var randReader = rand.New(rand.NewSource(time.Now().UnixNano()))
 
 func main() {
 	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})))
@@ -56,7 +53,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	// write data every 1 second
 	for i := 0; i < 10; i++ {
 		time.Sleep(1 * time.Second)
-		w.Write([]byte(fmt.Sprintf("data: %d\n\n", i)))
+		fmt.Fprintf(w, "data: %d\n\n", i)
 		flusher.Flush()
 	}
 	// write final data

--- a/option.go
+++ b/option.go
@@ -74,7 +74,7 @@ type runOptions struct {
 	workerTimeoutMergin                time.Duration
 	lambdaOptions                      []lambda.Option
 	lambdaMiddlewares                  []func(lambda.Handler) lambda.Handler
-	invokeModeStreamingResponse         bool
+	invokeModeStreamingResponse        bool
 }
 
 func defaultRunConfig(cancel context.CancelCauseFunc, sqsQueueName string) *runOptions {
@@ -581,6 +581,6 @@ func WithLambdaMiddlewares(middlewares ...func(lambda.Handler) lambda.Handler) O
 // if set this option, canyon lambda handler use this options.
 func WithStreamingResponse() Option {
 	return func(c *runOptions) {
-		c.invokeModeStramingResponse = true
+		c.invokeModeStreamingResponse = true
 	}
 }

--- a/option.go
+++ b/option.go
@@ -74,7 +74,7 @@ type runOptions struct {
 	workerTimeoutMergin                time.Duration
 	lambdaOptions                      []lambda.Option
 	lambdaMiddlewares                  []func(lambda.Handler) lambda.Handler
-	invokeModeStramingResponse         bool
+	invokeModeStreamingResponse         bool
 }
 
 func defaultRunConfig(cancel context.CancelCauseFunc, sqsQueueName string) *runOptions {

--- a/util.go
+++ b/util.go
@@ -334,7 +334,7 @@ func parseURL(urlStr string) (*url.URL, error) {
 	return u, nil
 }
 
-func isLambda() bool {
+func OnLambdaRuntime() bool {
 	return strings.HasPrefix(os.Getenv("AWS_EXECUTION_ENV"), "AWS_Lambda") || os.Getenv("AWS_LAMBDA_RUNTIME_API") != ""
 }
 


### PR DESCRIPTION
This pull request introduces several updates across the codebase, including enhancements to logging, support for AWS Lambda streaming responses, and updates to configuration and testing utilities. The most notable changes are the addition of a new Lambda streaming response feature, improvements to logging context handling, and updates to the `.lambdaignore` and `Makefile` for Lambda deployments.

### Enhancements to AWS Lambda functionality:
* Added a new `WithStreamingResponse` option to enable Lambda streaming responses. This allows the Lambda handler to support streaming data back to the client. (`option.go`: [option.goR579-R586](diffhunk://#diff-086a37ef11c8fd9a2516991339db79c207741ac98dd89c8215d31a8bead2814fR579-R586))
* Introduced a `function.json` file for configuring a Lambda function with streaming response capabilities, including environment variables and runtime settings. (`lambda/straming/function.json`: [lambda/straming/function.jsonR1-R21](diffhunk://#diff-e3809ec66ddb69699cf4801224e75e3c83c167c787695dbad512c54add08570fR1-R21))
* Added a `function_url.json` file to configure the Lambda function's URL with `RESPONSE_STREAM` invoke mode. (`lambda/straming/function_url.json`: [lambda/straming/function_url.jsonR1-R6](diffhunk://#diff-009c4cef010c52c2b246c37d9f715dc0cc6418b833b6fe989d0337ee113c8fafR1-R6))
* Updated the main Lambda handler in `main.go` to support streaming HTTP responses using `http.Flusher`. (`lambda/straming/main.go`: [lambda/straming/main.goR1-R65](diffhunk://#diff-0046661ae1121fb40a4bd57be55452dc66435884149d16b068beeb4b1a4501ffR1-R65))

### Improvements to logging:
* Refactored logging context handling by introducing the `loggerFromContext` function, which ensures a logger is retrieved from the context or defaults to the global logger. (`context.go`: [context.goL30-R42](diffhunk://#diff-552f47512a00afe5fc6850cc9ddc830a6daeca162750e50aab4ed549685e0253L30-R42))
* Updated verbose logging methods (`DebugContextWhenVarbose`, `InfoContextWhenVarbose`, and `WarnContextWhenVarbose`) to use the logger from the context when available. (`option.go`: [[1]](diffhunk://#diff-086a37ef11c8fd9a2516991339db79c207741ac98dd89c8215d31a8bead2814fL148-R162) [[2]](diffhunk://#diff-086a37ef11c8fd9a2516991339db79c207741ac98dd89c8215d31a8bead2814fL160-R188)

### Configuration and deployment updates:
* Updated `.lambdaignore` to exclude unnecessary files (e.g., `.gitignore`, `Makefile`, and Terraform files) from Lambda deployments. (`lambda/straming/.lambdaignore`: [lambda/straming/.lambdaignoreR1-R10](diffhunk://#diff-f5a322d49103aa0a667336d6884db66e20d2042b08cd76797df6883c3fbe47acR1-R10))
* Added a `Makefile` for building, cleaning, and deploying the Lambda function using `lambroll`. (`lambda/straming/Makefile`: [lambda/straming/MakefileR1-R17](diffhunk://#diff-665fd1e15d8af8b964bc341eeb5458ecdf44c5d0b18262d9cbb43510dc48d86bR1-R17))
* Updated the required Terraform version in `config.tf.example` to `1.9.8`. (`lambda/config.tf.example`: [lambda/config.tf.exampleL6-R6](diffhunk://#diff-8cc11489f40ccf9743856d447fab39503bed2c9b8b830a47ba419cfaf5885905L6-R6))

### Codebase enhancements and fixes:
* Replaced `isLambda` with `OnLambdaRuntime` for better readability and clarity in checking the Lambda runtime environment. (`util.go`: [util.goL337-R337](diffhunk://#diff-3a710ab6a1dd3264a76a1e4c4c3ebcee14762ef3a66f707726e17fd5fa255715L337-R337))
* Added a thread-safe `mutexWriter` utility to handle concurrent writes to a string buffer, improving test reliability. (`e2e_test.go`: [e2e_test.goR183-R203](diffhunk://#diff-afd03807d47884b5999d0bf7c69960a9b8f78c12c0157b2b38ecef988946204bR183-R203))
* Fixed incorrect usage of `MessageSystemAttributeNames` in the SQS input struct and updated related debug logs. (`aws.go`: [aws.goL184-R187](diffhunk://#diff-154b151b1a93f1cf611c8e2218f9aa40ccb227bae87071be7f82237e1c4649d3L184-R187))

### Updates to linting rules:
* Added several functions (e.g., `os.Setenv`, `io.Copy`, and `(*github.com/mashiike/canyon/canyontest.Runner).Close`) to the exclusion list in `.golangci.yaml` to suppress linting warnings for these specific cases. (`.golangci.yaml`: [.golangci.yamlR18-R32](diffhunk://#diff-9917ddc9f1c3304218f7269265b746d997c5c0615478177b5fceecd33ef47cb5R18-R32))